### PR TITLE
Issueワークフローのメタデータ同期条件を更新し、`issues.edited`イベントでも実行されるように変更。これにより、編集された…

### DIFF
--- a/.github/workflows/issue-opened-sync-metadata-and-branch.yml
+++ b/.github/workflows/issue-opened-sync-metadata-and-branch.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync issue metadata from Task form body
-        if: ${{ (github.event_name == 'issues' && github.event.action == 'opened') || (github.event_name == 'workflow_dispatch' && github.event.inputs.sync_metadata == 'true') }}
+        if: ${{ (github.event_name == 'issues' && (github.event.action == 'opened' || github.event.action == 'edited')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.sync_metadata == 'true') }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/00_共通/プロジェクト運用ルール/GitHub Actions仕様書/Issue同期とブランチ作成ワークフロー.md
+++ b/docs/00_共通/プロジェクト運用ルール/GitHub Actions仕様書/Issue同期とブランチ作成ワークフロー.md
@@ -61,7 +61,7 @@ on:
 
 補足：
 
-- **Step 1（メタデータ同期）**が実行されるのは `issues.opened`、または `workflow_dispatch` で `sync_metadata` が `true` のときのみ。それ以外の Issue イベントでは Step 1 はスキップし、Step 2（ブランチ処理）のみ行う。
+- **Step 1（メタデータ同期）**は `issues.opened` と `issues.edited` で実行される。`workflow_dispatch` では `sync_metadata` が `true` のときのみ実行される。`labeled` / `unlabeled` では Step 1 はスキップし、Step 2（ブランチ処理）のみ行う。
 - ProjectsのStatus変更を直接トリガーにするのはGitHub Actions標準では扱いづらいため、初期運用では対象外とする。
 - Status連動が必要な場合は、別途Projects連携ワークフローで対応する。
 


### PR DESCRIPTION
…Issueのメタデータも同期されるようになりました。関連ドキュメントも更新。 (#53)