### PR TITLE
docs(task-265): recoディレクトリ構成不整合棚卸し (#268)

### DIFF
--- a/.github/scripts/slack-notify.cjs
+++ b/.github/scripts/slack-notify.cjs
@@ -2,6 +2,17 @@
 
 const MARKER_PREFIX = "slack-thread:v1";
 const SLACK_POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage";
+const AI_REVIEW_HEADING_1 = "## 1. レビュー結果";
+const AI_REVIEW_HEADING_22 = "## 22. Status更新意図";
+const AUTOMATION_STATUS_COMMENT_PREFIX = "Project Status更新意図:";
+const SLACK_THREAD_MARKER_NOTE = "Slack thread marker for GitHub Actions automation.";
+const KNOWN_REVIEW_RESULTS = [
+  "approve_for_human_review",
+  "request_changes",
+  "needs_human_decision",
+  "split_required",
+  "blocked",
+];
 
 function nonEmpty(value) {
   return String(value || "").trim();
@@ -234,22 +245,117 @@ function relatedIssueNumber(prBody) {
   return 0;
 }
 
+function normalizeKnownReviewToken(value) {
+  const text = String(value || "").trim();
+  if (!text) return "";
+  const lowered = text.toLowerCase();
+  for (const item of KNOWN_REVIEW_RESULTS) {
+    if (lowered === item) return item;
+  }
+  if (text.includes("Human Reviewへ進行可")) return "approve_for_human_review";
+  if (text.includes("修正後に再AI Review")) return "request_changes";
+  if (text.includes("Human判断待ち")) return "needs_human_decision";
+  return "";
+}
+
 function normalizeReviewResult(value) {
+  const direct = normalizeKnownReviewToken(value);
+  if (direct) return direct;
   const text = String(value || "");
-  const known = [
-    "approve_for_human_review",
-    "request_changes",
-    "needs_human_decision",
-    "split_required",
-    "blocked",
-  ];
-  for (const item of known) {
+  for (const item of KNOWN_REVIEW_RESULTS) {
     if (text.includes(item)) return item;
   }
   if (text.includes("Human Reviewへ進行可")) return "approve_for_human_review";
   if (text.includes("修正後に再AI Review")) return "request_changes";
   if (text.includes("Human判断待ち")) return "needs_human_decision";
   return "";
+}
+
+function isAutomationBypassComment(body) {
+  const text = String(body || "").trimStart();
+  if (text.startsWith(AUTOMATION_STATUS_COMMENT_PREFIX)) return true;
+  if (text.includes(SLACK_THREAD_MARKER_NOTE)) return true;
+  if (text.includes(`<!-- ${MARKER_PREFIX}`)) return true;
+  return false;
+}
+
+function hasAiReviewResultHeading(body) {
+  const text = String(body || "");
+  return text.includes(AI_REVIEW_HEADING_1) || text.includes(AI_REVIEW_HEADING_22);
+}
+
+function hasReviewResultTableRow(body) {
+  return /\|\s*Review Result\s*\|/i.test(String(body || ""));
+}
+
+function isAiReviewResultComment(body) {
+  if (isAutomationBypassComment(body)) return false;
+  const text = String(body || "");
+  if (hasAiReviewResultHeading(text)) return true;
+  if (!hasReviewResultTableRow(text)) return false;
+  return Boolean(extractReviewResultTableCell(text));
+}
+
+function extractReviewResultTableCell(body) {
+  const text = String(body || "");
+  const backtick = /\|\s*Review Result\s*\|\s*`([^`]+)`\s*\|/i.exec(text);
+  if (backtick) return normalizeKnownReviewToken(backtick[1]);
+  const plain = /\|\s*Review Result\s*\|\s*([^\n|]+?)\s*\|/i.exec(text);
+  if (plain) return normalizeKnownReviewToken(plain[1]);
+  return "";
+}
+
+function extractReviewResultClassification(body) {
+  const text = String(body || "");
+  const match =
+    /###\s*レビュー結果分類\s*\r?\n\s*(?:```[^\n]*\r?\n)?\s*`?(approve_for_human_review|request_changes|needs_human_decision|split_required|blocked)`?/i.exec(
+      text,
+    );
+  if (!match) return "";
+  return normalizeKnownReviewToken(match[1]);
+}
+
+function extractReviewResultFromAiComment(body) {
+  if (!isAiReviewResultComment(body)) {
+    return { ok: false, reason: "not_ai_review_comment" };
+  }
+  const candidates = [];
+  const table = extractReviewResultTableCell(body);
+  if (table) candidates.push(table);
+  const classification = extractReviewResultClassification(body);
+  if (classification) candidates.push(classification);
+  const unique = [...new Set(candidates.filter(Boolean))];
+  if (unique.length === 1) return { ok: true, value: unique[0] };
+  if (unique.length > 1) return { ok: false, reason: "ambiguous_review_result" };
+  return { ok: false, reason: "review_result_not_found" };
+}
+
+function statusNamesEqual(a, b) {
+  return nonEmpty(a).toLowerCase() === nonEmpty(b).toLowerCase();
+}
+
+function expectedCurrentStatusForAiReview(reviewResult) {
+  const normalized = normalizeKnownReviewToken(reviewResult);
+  if (!normalized) return "";
+  return "AI Review";
+}
+
+function expectedCurrentStatusForHumanReview() {
+  return "Human Review";
+}
+
+function buildStatusSyncConfirmationComment({ taskIssueNumber, nextStatus }) {
+  return `Project Status更新意図: Issue #${taskIssueNumber} を \`${nextStatus}\` へ更新しました。`;
+}
+
+function reviewResultLabelForHumans(reviewResult) {
+  const normalized = normalizeKnownReviewToken(reviewResult);
+  if (normalized === "approve_for_human_review") return "Human Reviewへ進行可";
+  if (normalized === "request_changes") return "修正後に再AI Review";
+  if (normalized === "needs_human_decision") return "Human判断待ち";
+  if (normalized === "split_required") return "split_required";
+  if (normalized === "blocked") return "blocked";
+  return normalized || "不明";
 }
 
 function statusFromReviewResult(result, body) {
@@ -274,6 +380,10 @@ function notificationLevelFromReviewResult(result) {
 
 module.exports = {
   MARKER_PREFIX,
+  AI_REVIEW_HEADING_1,
+  AI_REVIEW_HEADING_22,
+  AUTOMATION_STATUS_COMMENT_PREFIX,
+  KNOWN_REVIEW_RESULTS,
   buildSlackText,
   buildThreadKey,
   buildThreadMarker,
@@ -284,7 +394,16 @@ module.exports = {
   upsertThreadMarkerComment,
   postSlackMessage,
   relatedIssueNumber,
+  normalizeKnownReviewToken,
   normalizeReviewResult,
+  isAutomationBypassComment,
+  isAiReviewResultComment,
+  extractReviewResultFromAiComment,
+  statusNamesEqual,
+  expectedCurrentStatusForAiReview,
+  expectedCurrentStatusForHumanReview,
+  buildStatusSyncConfirmationComment,
+  reviewResultLabelForHumans,
   statusFromReviewResult,
   notificationLevelFromReviewResult,
 };

--- a/.github/scripts/slack-notify.test.cjs
+++ b/.github/scripts/slack-notify.test.cjs
@@ -104,6 +104,91 @@ test("Review Result: 英語と日本語を正規化する", () => {
   assert.equal(slack.notificationLevelFromReviewResult("blocked"), "error");
 });
 
+const SAMPLE_AI_REVIEW = `# AI Review Result
+
+## 1. レビュー結果
+
+| 項目          | 内容                     |
+| ------------- | ------------------------ |
+| Review Result | \`approve_for_human_review\` |
+| 対象PR        | \`268\`                  |
+
+### Review Result の分類
+
+| 分類                       | 意味 |
+| approve_for_human_review | Human Review |
+
+## 22. Status更新意図
+
+| 次Status   | \`Human Review\` |
+`;
+
+test("isAutomationBypassComment: Status同期・Slack markerを除外する", () => {
+  assert.equal(
+    slack.isAutomationBypassComment(
+      "Project Status更新意図: Issue #265 を `Human Review` へ更新しました（Review Result: `approve_for_human_review`）。",
+    ),
+    true,
+  );
+  assert.equal(slack.isAutomationBypassComment(slack.buildThreadMarkerCommentBody({
+    threadKey: "pr:o/r#1",
+    channel: "C1",
+    ts: "1.000",
+  })), true);
+  assert.equal(slack.isAutomationBypassComment(SAMPLE_AI_REVIEW), false);
+});
+
+test("isAiReviewResultComment: AI Reviewテンプレのみtrue", () => {
+  assert.equal(slack.isAiReviewResultComment(SAMPLE_AI_REVIEW), true);
+  assert.equal(
+    slack.isAiReviewResultComment("Project Status更新意図: Issue #1 を `Human Review` へ更新しました。"),
+    false,
+  );
+  assert.equal(slack.isAiReviewResultComment("random approve_for_human_review mention"), false);
+});
+
+test("extractReviewResultFromAiComment: §1表から一意に抽出する", () => {
+  const extracted = slack.extractReviewResultFromAiComment(SAMPLE_AI_REVIEW);
+  assert.equal(extracted.ok, true);
+  assert.equal(extracted.value, "approve_for_human_review");
+});
+
+test("extractReviewResultFromAiComment: 運用確認コメントは対象外", () => {
+  const extracted = slack.extractReviewResultFromAiComment(
+    "Project Status更新意図: Issue #265 を `Human Review` へ更新しました（Review Result: approve_for_human_review）。",
+  );
+  assert.equal(extracted.ok, false);
+  assert.equal(extracted.reason, "not_ai_review_comment");
+});
+
+test("buildStatusSyncConfirmationComment: Review Result enumを含めない", () => {
+  const body = slack.buildStatusSyncConfirmationComment({ taskIssueNumber: 265, nextStatus: "Human Review" });
+  assert.match(body, /^Project Status更新意図:/);
+  assert.equal(body.includes("approve_for_human_review"), false);
+  assert.equal(slack.isAutomationBypassComment(body), true);
+});
+
+test("statusNamesEqual: 大文字小文字を無視する", () => {
+  assert.equal(slack.statusNamesEqual("AI Review", "ai review"), true);
+  assert.equal(slack.statusNamesEqual("Human Review", "In Progress"), false);
+});
+
+test("expectedCurrentStatusForAiReview: AI Review前提", () => {
+  assert.equal(slack.expectedCurrentStatusForAiReview("approve_for_human_review"), "AI Review");
+});
+
+test("ループ再現: AI Review1回+確認コメントは追加トリガにならない", () => {
+  const ai = SAMPLE_AI_REVIEW;
+  const confirm = slack.buildStatusSyncConfirmationComment({
+    taskIssueNumber: 265,
+    nextStatus: "Human Review",
+  });
+  assert.equal(slack.isAiReviewResultComment(ai), true);
+  assert.equal(slack.isAiReviewResultComment(confirm), false);
+  assert.equal(slack.isAutomationBypassComment(confirm), true);
+  assert.equal(slack.extractReviewResultFromAiComment(confirm).ok, false);
+});
+
 test("upsertThreadMarkerComment: 既存markerがあれば更新する", async () => {
   const calls = [];
   const github = {

--- a/.github/workflows/pr-review-status-sync.yml
+++ b/.github/workflows/pr-review-status-sync.yml
@@ -4,7 +4,6 @@ on:
   issue_comment:
     types:
       - created
-      - edited
   pull_request_review:
     types:
       - submitted
@@ -28,7 +27,7 @@ permissions:
 
 concurrency:
   group: pr-review-status-sync-${{ github.event.issue.number || github.event.inputs.pr_number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   sync-status:
@@ -60,21 +59,12 @@ jobs:
             const projectOwner = process.env.PROJECT_OWNER || owner;
             const projectNumber = Number(process.env.PROJECT_NUMBER || "4");
 
-            function reviewResultFromBody(body) {
-              return slack.normalizeReviewResult(body);
-            }
-
             function nextStatusFromReviewResult(result, body) {
               return slack.statusFromReviewResult(result, body);
             }
 
             function relatedIssueNumber(prBody) {
-              const text = String(prBody || "");
-              const related = /Related to\s+#(\d+)/i.exec(text);
-              if (related) return Number(related[1]);
-              const closes = /(Closes|Close|Closed|Fixes|Fix)\s+#(\d+)/i.exec(text);
-              if (closes) return Number(closes[2]);
-              return 0;
+              return slack.relatedIssueNumber(prBody);
             }
 
             async function comment(issueNumber, body) {
@@ -146,6 +136,23 @@ jobs:
               }
             }
 
+            async function readProjectItemStatus(projectId, itemId) {
+              const query = `
+                query($projectId: ID!, $itemId: ID!) {
+                  node(id: $projectId) {
+                    ... on ProjectV2 {
+                      item(id: $itemId) {
+                        fieldValueByName(name: "Status") {
+                          ... on ProjectV2ItemFieldSingleSelectValue { name }
+                        }
+                      }
+                    }
+                  }
+                }`;
+              const data = await github.graphql(query, { projectId, itemId });
+              return data.node?.item?.fieldValueByName?.name || "";
+            }
+
             async function updateStatus(project, itemId, statusName) {
               const statusField = project.fields.nodes.find((field) => field.name === "Status");
               const option = statusField?.options?.find((candidate) => candidate.name === statusName);
@@ -173,15 +180,28 @@ jobs:
               });
             }
 
+            function skipWithSummary(reason, details = {}) {
+              core.info(`Skipped: ${reason}`);
+              const lines = [`Skipped: ${reason}`];
+              for (const [key, value] of Object.entries(details)) {
+                if (value !== undefined && value !== "") lines.push(`${key}: ${value}`);
+              }
+              return core.summary.addRaw(lines.join("\n") + "\n").write();
+            }
+
             let prNumber;
             let reviewResult;
             let reviewBody = "";
+            let route = "";
+
             if (context.eventName === "workflow_dispatch") {
+              route = "dispatch";
               prNumber = Number(context.payload.inputs.pr_number);
               reviewBody = String(context.payload.inputs.review_result || "");
-              reviewResult = reviewResultFromBody(reviewBody);
+              reviewResult = slack.normalizeReviewResult(reviewBody);
               if (!reviewResult) reviewResult = String(context.payload.inputs.review_result || "");
             } else if (context.eventName === "pull_request_review") {
+              route = "human_review";
               const review = context.payload.review;
               if (review?.state !== "changes_requested") {
                 core.info("Pull request review is not changes_requested; skipped.");
@@ -191,14 +211,27 @@ jobs:
               reviewResult = "request_changes";
               reviewBody = review.body || "";
             } else {
+              route = "ai_review_comment";
               const issue = context.payload.issue;
               if (!issue?.pull_request) {
                 core.info("Comment is not on a pull request; skipped.");
                 return;
               }
+              const commentBody = context.payload.comment?.body || "";
+              if (slack.isAutomationBypassComment(commentBody)) {
+                return skipWithSummary("automation_comment", { PR: `#${issue.number}` });
+              }
+              if (!slack.isAiReviewResultComment(commentBody)) {
+                return skipWithSummary("not_ai_review_comment", { PR: `#${issue.number}` });
+              }
               prNumber = issue.number;
-              reviewBody = context.payload.comment?.body || "";
-              reviewResult = reviewResultFromBody(reviewBody);
+              reviewBody = commentBody;
+              const extracted = slack.extractReviewResultFromAiComment(commentBody);
+              if (!extracted.ok) {
+                core.setFailed(`Review Result parse failed: ${extracted.reason}`);
+                return;
+              }
+              reviewResult = extracted.value;
             }
 
             const nextStatus = nextStatusFromReviewResult(reviewResult, reviewBody);
@@ -234,8 +267,35 @@ jobs:
               return;
             }
 
+            const currentStatus = await readProjectItemStatus(project.id, itemId);
+            const expectedCurrent =
+              route === "human_review"
+                ? slack.expectedCurrentStatusForHumanReview()
+                : slack.expectedCurrentStatusForAiReview(reviewResult);
+
+            if (expectedCurrent && currentStatus && !slack.statusNamesEqual(currentStatus, expectedCurrent)) {
+              return skipWithSummary("current_status_mismatch", {
+                PR: `#${prNumber}`,
+                Issue: `#${taskIssueNumber}`,
+                "Current Status": currentStatus,
+                "Expected Status": expectedCurrent,
+                "Next Status": nextStatus,
+              });
+            }
+
+            if (currentStatus && slack.statusNamesEqual(currentStatus, nextStatus)) {
+              return skipWithSummary("already_at_next_status", {
+                PR: `#${prNumber}`,
+                Issue: `#${taskIssueNumber}`,
+                Status: currentStatus,
+              });
+            }
+
             await updateStatus(project, itemId, nextStatus);
-            await comment(prNumber, `Project Status更新意図: Issue #${taskIssueNumber} を \`${nextStatus}\` へ更新しました（Review Result: \`${reviewResult}\`）。`);
+            await comment(
+              prNumber,
+              slack.buildStatusSyncConfirmationComment({ taskIssueNumber, nextStatus }),
+            );
 
             const channel = process.env.SLACK_CHANNEL_ID_DEVOPS || "";
             const threadKey = slack.buildThreadKey({ owner, repo, kind: "pr", number: prNumber });
@@ -247,7 +307,7 @@ jobs:
             const text = slack.buildSlackText({
               level,
               title,
-              summary: `Review Result: ${reviewResult}`,
+              summary: `Review Result: ${slack.reviewResultLabelForHumans(reviewResult)}`,
               mention,
               fields: {
                 PR: `#${prNumber}`,
@@ -284,7 +344,9 @@ jobs:
 
             await core.summary
               .addHeading("PRレビュー Status / Slack通知")
-              .addRaw(`PR: #${prNumber}\n\nIssue: #${taskIssueNumber}\n\nReview Result: \`${reviewResult}\`\n\nNext Status: \`${nextStatus}\`\n\nSlack: ${result.ok ? "ok" : "failed"}\n`)
+              .addRaw(
+                `PR: #${prNumber}\n\nIssue: #${taskIssueNumber}\n\nRoute: \`${route}\`\n\nReview Result: \`${reviewResult}\`\n\nCurrent Status: \`${currentStatus || "unknown"}\`\n\nNext Status: \`${nextStatus}\`\n\nSlack: ${result.ok ? "ok" : "failed"}\n`,
+              )
               .addRaw(result.error ? `\nSlack error: \`${result.error}\`\n` : "")
               .write();
             if (!result.ok) {

--- a/docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md
@@ -64,14 +64,26 @@ Status の正式値は [Projects運用ルール.md](../../00_共通/プロジェ
 
 | 項目                       | 内容                                                                               |
 | ------------------------ | -------------------------------------------------------------------------------- |
-| `on.issue_comment`       | `types: [created]`。PR Issue コメント（AI Review 結果）を対象                                |
+| `on.issue_comment`       | `types: [created]` のみ。PR Issue コメント（AI Review 結果）を対象。**`edited` は対象外**（Slack thread marker 更新等による再実行を防ぐ） |
 | `on.pull_request_review` | `types: [submitted]`。`state: changes_requested` を Human 経路で処理                    |
-| `on.workflow_dispatch`   | 手動実行（検証・再実行用）。入力: Issue 番号、経路、Review Result 等                                    |
+| `on.workflow_dispatch`   | 手動実行（検証・再実行用）。入力: PR 番号、Review Result 等                                    |
 | `permissions`            | `contents: read`、`issues: write`、`pull-requests: read`（PR・コメント参照）。Project API は `PROJECTS_TOKEN` |
-| `concurrency`            | `project-status-by-pr-review`（同一 Project 更新の競合を直列化。`cancel-in-progress: false`）  |
+| `concurrency`            | `pr-review-status-sync-<PR番号>`（同一 PR の更新を直列化。**`cancel-in-progress: true`** で重複 Run を抑止）  |
 
 
 PR コメント経路では、**Pull Request** に紐づく Issue コメントのみを処理する（通常 Issue コメントはスキップ）。
+
+### 3.1 再実行ループ防止（必須）
+
+過去に、Status 更新後の **運用確認コメント** 本文へ `approve_for_human_review` 等を埋め込んだことで、`issue_comment` が連鎖しワークフローが多数回実行された。以下を実装の必須要件とする。
+
+| 対策 | 内容 |
+| ---- | ---- |
+| 運用コメントのバイパス | `Project Status更新意図:` で始まるコメント、Slack thread marker コメントは **AI 経路の対象外**（成功終了・処理なし） |
+| §6.1 の厳格適用 | AI Review 結果は [ai-review-comment.md](../../../prompts/templates/review/ai-review-comment.md) 形式（`## 1. レビュー結果` 等）のみ処理。全文部分一致は使わない |
+| 確認コメント | Status 更新後の PR コメントに **Review Result の enum 文字列を含めない** |
+| 冪等（§5.3） | GraphQL で現在 Status を読み、前提不一致・次 Status と同一なら更新・確認コメント・Slack を行わない |
+| 並行制御 | 同一 PR で `cancel-in-progress: true` |
 
 ## 4. シークレット・定数
 
@@ -163,13 +175,21 @@ Human 経路では Review Result のパースは行わないため、本節は A
 
 ## 6. 機械判定: Review Result の抽出（AI 経路）
 
+### 6.0 処理対象外コメント（バイパス）
+
+次の PR コメントは **AI 経路の入力に使わない**。ジョブは成功終了し、Summary に skipped 理由を記録する。
+
+| 条件 | 例 |
+| ---- | --- |
+| 本文が `Project Status更新意図:` で始まる | 本ワークフローが Status 更新後に投稿する確認コメント |
+| Slack thread marker コメント | `<!-- slack-thread:v1 ... -->` を含むコメント |
+
 ### 6.1 AI Review コメントの識別
 
-次のいずれかを満たすコメントを AI Review 結果とみなす。
+§6.0 に該当しないうえで、次のいずれかを満たすコメントを AI Review 結果とみなす。
 
 - 本文に見出し `## 1. レビュー結果` または `## 22. Status更新意図` が含まれる
-- 表形式で `Review Result` 行が存在し、次のいずれかの値が記載されている  
-`approve_for_human_review` / `request_changes` / `needs_human_decision` / `split_required` / `blocked`
+- 表形式で `Review Result` 行が存在し、§1 の表セルから許容値が **1 件** 抽出できる
 
 Bot 投稿・人間投稿を問わない。フォーマットが [ai-review-comment.md](../../../prompts/templates/review/ai-review-comment.md) に従っていることを前提とする。
 
@@ -179,9 +199,12 @@ Bot 投稿・人間投稿を問わない。フォーマットが [ai-review-comm
 
 §6.1 に該当するコメントについて、次の優先順位で **1 件に定まる** 値を得る。定まらない場合は §5.4 のパース失敗とする。
 
-1. `Review Result | \``` 形式の表セル（§1 の表）`
-2. `### レビュー結果分類` 直下の単独行
-3. `approve_for_human_review` 等のキーワード（フォールバック。**複数一致** または **許容値以外** はパース失敗）
+1. `Review Result | \`` 形式の表セル（§1 の表）
+2. `### レビュー結果分類` 直下の単一行
+
+**禁止**: コメント全文への `approve_for_human_review` 等の部分一致フォールバック（運用確認コメント・分類表の列挙と誤判定し、再実行ループの原因になる）。
+
+§6.1 に該当するが 1・2 で値が定まらない、または複数定まる場合は §5.4 のパース失敗とする。
 
 ### 6.3 次Status の明示（needs_human_decision 用）
 
@@ -205,14 +228,15 @@ Bot 投稿・人間投稿を問わない。フォーマットが [ai-review-comm
 ## 7. 処理概要
 
 1. イベント種別に応じて AI 経路または Human 経路を選択する
-2. `actions/checkout` で `pr-review-status-policy.cjs` を読み込む
+2. `actions/checkout` で `.github/scripts/slack-notify.cjs` を読み込む（§6 識別・§5.3 照合・確認コメント文案）
 3. GraphQL で Project の **Status** フィールド ID と遷移先オプション ID を解決する
-4. 対象 Issue の Project item を特定し、現在 Status を読む
-5. §5 の遷移表に従い次 Status を決定する（§5.3 のスキップ条件に該当すれば更新せず記録）
+4. 対象 Issue の Project item を特定し、**現在 Status** を `fieldValueByName(name: "Status")` で読む
+5. §5 の遷移表に従い次 Status を決定する（§5.3 のスキップ条件に該当すれば更新・確認コメント・Slack を行わず記録）
 6. `updateProjectV2ItemFieldValue` で Status を更新する
-7. Review Resultに応じてSlack通知を送信する
-8. ジョブサマリーに Issue 番号・経路・Review Result・更新前後 Status・Slack通知結果を出力する
-9. §5.4 に該当した場合は `core.setFailed` し、Summary に PR 番号・Issue 番号（解決できた場合）・失敗理由・コメント URL を出力する
+7. PR に確認コメントを 1 件投稿する（`Project Status更新意図: Issue #<n> を \`<次Status>\` へ更新しました。`。**Review Result enum は含めない**）
+8. Review Result に応じて Slack 通知を送信する（Slack 本文の Review Result は人間向けラベル可）
+9. ジョブサマリーに Issue 番号・経路・Review Result・更新前後 Status・Slack 通知結果を出力する
+10. §5.4 に該当した場合は `core.setFailed` し、Summary に PR 番号・Issue 番号（解決できた場合）・失敗理由・コメント URL を出力する
 
 ## 8. GraphQL
 
@@ -230,7 +254,7 @@ Bot 投稿・人間投稿を問わない。フォーマットが [ai-review-comm
 | ----------------------------------------------------- | ----------------------------------------------- |
 | Project が取得できない                                       | `core.setFailed` でジョブ失敗                         |
 | `Status` フィールドまたは遷移先オプションが見つからない                      | `core.setFailed` でジョブ失敗                         |
-| AI 判定に非該当のコメント（§6.1 未満足）                              | ジョブ成功（処理なし）                                     |
+| AI 判定に非該当のコメント（§6.0 バイパス・§6.1 未満足）                   | ジョブ成功（Summary に skipped）                           |
 | 正当スキップのみで更新 0 件（§5.3）                                 | ジョブ成功（Summary に 0 件・skipped 内訳）                 |
 | AI Review 結果コメントと判定したが Review Result を一意に抽出できない（§5.4） | `core.setFailed`（Summary に PR 番号・失敗理由・コメント URL） |
 | AI Review 結果コメントと判定したが Task Issue を解決できない（§5.4）       | `core.setFailed`（Summary に PR 番号・失敗理由・コメント URL） |
@@ -244,7 +268,8 @@ Slack通知に失敗しても、Projects Status の更新は取り消さない�
 ## 10. 運用上の必須事項
 
 - Project の Status に **AI Review** / **Human Review** / **In Progress** が存在し、表示名が [Projects運用ルール.md](../../00_共通/プロジェクト管理/Projects運用ルール.md) §9 と一致すること
-- `/review-pr` は PR コメントを [ai-review-comment.md](../../../prompts/templates/review/ai-review-comment.md) 形式で投稿すること（Review Result 行を省略しない）
+- `/review-pr` は PR コメントを [ai-review-comment.md](../../../prompts/templates/review/ai-review-comment.md) 形式で投稿すること（Review Result 行を省略しない）。**運用確認コメントと混同しない**
+- 本ワークフローが投稿する確認コメントを手動編集して Review Result 行を足さないこと（再実行ループの原因になる）
 - PR 本文に Task Issue への参照（`Related to #<n>` 等）を含めること（§6.4）。不足時はワークフローが失敗する
 - 本ワークフローが **失敗（赤）** した場合は、Summary の PR・失敗理由を確認し、テンプレート・コメント・Issue 参照を修正してから再実行すること
 - `PROJECTS_TOKEN` には対象 Project の読み書きに必要なスコープを付与すること

--- a/docs/06_実装設計/reco/recoディレクトリ構成不整合棚卸し.md
+++ b/docs/06_実装設計/reco/recoディレクトリ構成不整合棚卸し.md
@@ -1,0 +1,50 @@
+# recoディレクトリ構成不整合棚卸し
+
+## 1. 目的と基準
+
+- 目的: `apps/reco` 配下のパス表記揺れを棚卸しし、`src/reco` 統一方針への更新対象を特定する。
+- 基準正本: `docs/00_共通/ディレクトリ構成/プロジェクトディレクトリ構成定義書.md`
+- 本棚卸しは docs / prompts の不整合整理のみを対象とし、実装変更は扱わない。
+
+## 2. 対象範囲
+
+- `docs/` 配下の `apps/reco` 関連記述
+- `prompts/definitions/` 配下の `epic_scope` / `review_points` / 背景記述
+
+## 3. 分類定義
+
+| 分類 | 定義 | 優先度目安 |
+| --- | --- | --- |
+| 正本矛盾 | 正本方針（`src/reco`）と直接矛盾する記述 | 高 |
+| 運用ルール矛盾 | Epic/Task境界やレビュー運用の前提が旧構成依存になっている記述 | 中 |
+| 参照メモ | 背景メモ・注記等で旧パスが残る記述（直ちに誤動作はしない） | 低 |
+
+## 4. 不整合一覧（出典ファイル単位）
+
+| No | 分類 | 出典ファイル | 現在記述（要約） | `src/reco` 基準との差分 | 優先度 | 後続Task |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | 正本矛盾 | `prompts/definitions/epics/api-int-002-reco-recommendation-run/epic.yaml` | エンドポイント層を `apps/reco/src/app/**` と定義 | 正式方針は `apps/reco/src/reco/api/**` | 高 | `definition-update` |
+| 2 | 正本矛盾 | `prompts/definitions/epics/mod-reco-001-recommendation-orchestrator/epic.yaml` | モジュール境界を `apps/reco/src/modules/**` 基準で記述 | 正式方針は `apps/reco/src/reco/application/**` を基準化 | 高 | `definition-update` |
+| 3 | 正本矛盾 | `prompts/definitions/tasks/mod-reco-001-recommendation-orchestrator/module-spec.yaml` | API-INT境界除外を `apps/reco/src/app/**` で注記 | 正式方針は `apps/reco/src/reco/api/**` で除外定義 | 高 | `definition-update` |
+| 4 | 運用ルール矛盾 | `docs/00_共通/AIエージェント運用/Task Definition設計書.md` | API-INT境界説明が `apps/reco/src/app/**` 前提 | 境界規約が `src/reco/api` へ未追従 | 中 | `docs-update` |
+| 5 | 運用ルール矛盾 | `docs/00_共通/AIエージェント運用/AIレビュー運用設計書.md` | レビュー観点が `apps/reco/src/app/**` / `src/modules/**` を前提 | レビュー観点を `src/reco/*` 系へ再定義が必要 | 中 | `docs-update` |
+| 6 | 参照メモ | `prompts/definitions/reviews/api-int-002-reco-recommendation-run/pr-review.yaml` | リスク/確認観点に `apps/reco/src/modules` 等の旧構成メモ | 背景メモの参照先が新構成へ未置換 | 低 | `migration-guide` |
+| 7 | 参照メモ | `prompts/definitions/epics/reco-directory-architecture-redesign/epic.yaml` | 「揺れ」として `src/modules/**` / `src/app/**` を併記 | 棚卸し後は旧表記を移行注記へ限定する必要 | 低 | `migration-guide` |
+
+## 5. 更新順序（引き継ぎ）
+
+1. `definition-update`（高優先）  
+   Epic/Task Definition の `allowed_paths` / `forbidden_paths` / review points を `src/reco` 基準へ統一する。
+2. `docs-update`（中優先）  
+   Task Definition設計書・AIレビュー運用設計書の境界説明を `src/reco` 基準へ更新する。
+3. `migration-guide`（低優先）  
+   旧表記を残す必要がある箇所を「移行履歴/参照メモ」に限定し、現行ルール本文から分離する。
+
+## 6. scope外明示
+
+本Taskでは以下を実施しない。
+
+- 実装コード変更（`apps/reco` 配下のPython実装）
+- OpenAPI 変更
+- DB schema 変更
+- 実際の Definition/Review ファイル更新（本書は棚卸しのみ）


### PR DESCRIPTION
* docs: recoディレクトリ構成不整合棚卸しを作成

* feat: Enhance Slack notification script for AI review results

- Added functions to normalize and extract AI review results from comments, including handling specific headings and table formats.
- Implemented checks to identify automation bypass comments and ensure proper processing of AI review results.
- Updated the workflow to prevent re-execution loops by excluding certain comment types and ensuring unique extraction of review results.
- Enhanced documentation to clarify the new AI review handling processes and requirements.

## PR Template選択ガイド

このPR本文は種別別テンプレート未指定時の案内用です。PR種別に応じて、以下いずれかのテンプレートを使用してください。

| PR種別 | GitHub PR Template | Issue参照 | PR target |
| ------ | ------------------ | --------- | --------- |
| Task PR | `.github/PULL_REQUEST_TEMPLATE/task-pr.md` | `Related to #<Task Issue番号>` | Parent Epic Branch |
| Contract Task PR | `.github/PULL_REQUEST_TEMPLATE/contract-pr.md` | `Related to #<Task Issue番号>` | Parent Epic Branch |
| Epic PR | `.github/PULL_REQUEST_TEMPLATE/epic-pr.md` | `Closes #<Epic Issue番号>` | `develop` |

GitHub UIで手動作成する場合は、PR作成URLに `template=task-pr.md` / `template=contract-pr.md` / `template=epic-pr.md` を指定してください。

```text
?template=task-pr.md
?template=contract-pr.md
?template=epic-pr.md
```

GitHub CLIで作成する場合は、対象PR種別に対応するテンプレートを明示してください。

```bash
gh pr create --template .github/PULL_REQUEST_TEMPLATE/task-pr.md
gh pr create --template .github/PULL_REQUEST_TEMPLATE/contract-pr.md
gh pr create --template .github/PULL_REQUEST_TEMPLATE/epic-pr.md
```

AI主導PR作成では、`prompts/templates/pr/` 配下のPrompt PR Templateを正本としてPR本文を生成します。

PR本文には `/review-pr` などの次Actionコマンドを記載しません。次ActionはCommand実行手順またはレビュー依頼コメントで扱います。
