### PR TITLE
fix: pr-review-status-syncの現在Status読取GraphQLを修正

### DIFF
--- a/.github/workflows/pr-review-status-sync.yml
+++ b/.github/workflows/pr-review-status-sync.yml
@@ -136,21 +136,19 @@ jobs:
               }
             }
 
-            async function readProjectItemStatus(projectId, itemId) {
+            async function readProjectItemStatus(itemId) {
               const query = `
-                query($projectId: ID!, $itemId: ID!) {
-                  node(id: $projectId) {
-                    ... on ProjectV2 {
-                      item(id: $itemId) {
-                        fieldValueByName(name: "Status") {
-                          ... on ProjectV2ItemFieldSingleSelectValue { name }
-                        }
+                query($itemId: ID!) {
+                  node(id: $itemId) {
+                    ... on ProjectV2Item {
+                      fieldValueByName(name: "Status") {
+                        ... on ProjectV2ItemFieldSingleSelectValue { name }
                       }
                     }
                   }
                 }`;
-              const data = await github.graphql(query, { projectId, itemId });
-              return data.node?.item?.fieldValueByName?.name || "";
+              const data = await github.graphql(query, { itemId });
+              return data.node?.fieldValueByName?.name || "";
             }
 
             async function updateStatus(project, itemId, statusName) {
@@ -267,7 +265,7 @@ jobs:
               return;
             }
 
-            const currentStatus = await readProjectItemStatus(project.id, itemId);
+            const currentStatus = await readProjectItemStatus(itemId);
             const expectedCurrent =
               route === "human_review"
                 ? slack.expectedCurrentStatusForHumanReview()


### PR DESCRIPTION
## Summary

- `readProjectItemStatus` が `ProjectV2.item(id:)` を参照して GraphQL エラーになっていた
- `ProjectV2Item` ノードの `fieldValueByName` で現在 Status を読むよう修正

## Test plan

- develop マージ後、Issue #270 / PR #271 で AI Review を再実行し、workflow が 1 回 success すること
