### PR TITLE
fix-migrate-pr-review-status-sync-to-repository-dispatch

### DIFF
--- a/.cursor/commands/review-pr.md
+++ b/.cursor/commands/review-pr.md
@@ -454,6 +454,44 @@ AIレビュー結果をPRへ記録する。
 - follow-up Issue候補
 - Human Review観点
 
+PR コメントは [ai-review-comment.md](../../prompts/templates/review/ai-review-comment.md) 形式とする。特に §1 の `Review Result` 行と §22 の `次Status` を省略しない。
+
+---
+
+### 15.5 Projects Status 同期を起動する（必須）
+
+PR コメント投稿後、**必ず 1 回** [PR review status sync](../../.github/workflows/pr-review-status-sync.yml) を `repository_dispatch` で起動する。
+
+Status 更新はコメント投稿では自動検知しない。dispatch 忘れは Projects Status が `AI Review` のまま残る。
+
+```bash
+node .github/scripts/dispatch-pr-review-status-sync.cjs \
+  --repository <owner>/<repo> \
+  --pr <PR番号> \
+  --review-result <approve_for_human_review|request_changes|needs_human_decision|split_required|blocked>
+```
+
+`needs_human_decision` で PR コメント §22 の `次Status` が `In Progress` のときは、コメント本文を渡す。
+
+```bash
+node .github/scripts/dispatch-pr-review-status-sync.cjs \
+  --repository <owner>/<repo> \
+  --pr <PR番号> \
+  --review-result needs_human_decision \
+  --review-body-file /path/to/ai-review-comment.md
+```
+
+代替（`gh` のみ）:
+
+```bash
+gh api repos/<owner>/<repo>/dispatches \
+  -f event_type=ai_review_status_sync \
+  -f "client_payload[pr_number]=<PR番号>" \
+  -f "client_payload[review_result]=<Review Result>"
+```
+
+dispatch が失敗した場合は、PR コメントは残るが Status は更新されない。ログを確認し、修正後に `workflow_dispatch` または dispatch を再実行する。
+
 ---
 
 ### 16. 指摘なしなら Human Review へ進める
@@ -521,6 +559,7 @@ Status更新は、Commandが直接確定するのではなく、GitHub Actions�
 - 横断影響が確認されている
 - 前段成果物の修正要否が確認されている
 - PRへAIレビュー結果が記録されている
+- `repository_dispatch`（`ai_review_status_sync`）を 1 回起動している
 - 修正要否が明確である
 - Human Reviewへ進めてよいか判断できる
 - 指摘がある場合、修正対象が明確である
@@ -590,9 +629,7 @@ Status更新は、Commandが直接確定するのではなく、GitHub Actions�
 | split_required           | `In Progress`                       |
 | blocked                  | `In Progress`                       |
 
-Status更新は、Commandが直接確定するのではなく、[PRレビュー完了時Status更新ワークフロー仕様書](../../docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md) が実施する。`/review-pr` は更新意図として明確に出力する。
-
-PR コメントは [ai-review-comment.md](../../prompts/templates/review/ai-review-comment.md) 形式とする。特に §1 の `Review Result` 行と §22 の `次Status` を省略しない（workflow の機械判定に使用する）。
+Status更新は、Commandが直接確定するのではなく、[PRレビュー完了時Status更新ワークフロー仕様書](../../docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md) が実施する。`/review-pr` は §15.5 の **repository_dispatch を 1 回** 呼び出し、更新意図を PR コメントにも明記する。
 
 ---
 

--- a/.github/scripts/dispatch-pr-review-status-sync.cjs
+++ b/.github/scripts/dispatch-pr-review-status-sync.cjs
@@ -1,0 +1,189 @@
+"use strict";
+
+const slack = require("./slack-notify.cjs");
+
+const EVENT_TYPE = "ai_review_status_sync";
+
+function nonEmpty(value) {
+  return String(value || "").trim();
+}
+
+function resolveRepository({ owner, repo, repository }) {
+  if (owner && repo) return { owner: nonEmpty(owner), repo: nonEmpty(repo) };
+  const full = nonEmpty(repository) || nonEmpty(process.env.GITHUB_REPOSITORY);
+  if (!full || !full.includes("/")) {
+    throw new Error("repository is required (--owner/--repo or GITHUB_REPOSITORY)");
+  }
+  const [resolvedOwner, resolvedRepo] = full.split("/", 2);
+  return { owner: resolvedOwner, repo: resolvedRepo };
+}
+
+function buildClientPayload({ prNumber, reviewResult, reviewBody }) {
+  const normalized = slack.normalizeKnownReviewToken(reviewResult);
+  if (!normalized) {
+    throw new Error(
+      `Invalid review_result: ${reviewResult}. Use approve_for_human_review, request_changes, needs_human_decision, split_required, or blocked.`,
+    );
+  }
+  const pr = Number(prNumber);
+  if (!Number.isInteger(pr) || pr <= 0) {
+    throw new Error(`Invalid pr_number: ${prNumber}`);
+  }
+  const payload = {
+    pr_number: String(pr),
+    review_result: normalized,
+  };
+  const body = nonEmpty(reviewBody);
+  if (body) payload.review_body = body;
+  return payload;
+}
+
+function dispatchUrl(owner, repo) {
+  return `https://api.github.com/repos/${owner}/${repo}/dispatches`;
+}
+
+async function dispatchPrReviewStatusSync({
+  owner,
+  repo,
+  repository,
+  prNumber,
+  reviewResult,
+  reviewBody,
+  token,
+  dryRun,
+  fetchImpl,
+}) {
+  const resolved = resolveRepository({ owner, repo, repository });
+  const authToken = nonEmpty(token) || nonEmpty(process.env.GITHUB_TOKEN) || nonEmpty(process.env.GH_TOKEN);
+  if (!authToken) {
+    throw new Error("GITHUB_TOKEN or GH_TOKEN is required to dispatch repository_dispatch");
+  }
+  const clientPayload = buildClientPayload({ prNumber, reviewResult, reviewBody });
+  if (dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      eventType: EVENT_TYPE,
+      owner: resolved.owner,
+      repo: resolved.repo,
+      clientPayload,
+    };
+  }
+
+  const send = fetchImpl || global.fetch;
+  if (typeof send !== "function") {
+    throw new Error("fetch is unavailable");
+  }
+
+  const response = await send(dispatchUrl(resolved.owner, resolved.repo), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: JSON.stringify({
+      event_type: EVENT_TYPE,
+      client_payload: clientPayload,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`repository_dispatch failed: HTTP ${response.status} ${text}`.trim());
+  }
+
+  return {
+    ok: true,
+    eventType: EVENT_TYPE,
+    owner: resolved.owner,
+    repo: resolved.repo,
+    clientPayload,
+  };
+}
+
+function parseCliArgs(argv) {
+  const args = argv.slice(2);
+  const options = {
+    owner: "",
+    repo: "",
+    repository: "",
+    prNumber: "",
+    reviewResult: "",
+    reviewBody: "",
+    dryRun: false,
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--owner") {
+      options.owner = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repository" || arg === "-R") {
+      options.repository = args[++i] || "";
+      continue;
+    }
+    if (arg === "--pr" || arg === "--pr-number") {
+      options.prNumber = args[++i] || "";
+      continue;
+    }
+    if (arg === "--review-result") {
+      options.reviewResult = args[++i] || "";
+      continue;
+    }
+    if (arg === "--review-body-file") {
+      const fs = require("fs");
+      const filePath = args[++i] || "";
+      options.reviewBody = fs.readFileSync(filePath, "utf8");
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node .github/scripts/dispatch-pr-review-status-sync.cjs \\
+    --pr <number> --review-result <approve_for_human_review|request_changes|...> \\
+    [--repository owner/repo] [--review-body-file path] [--dry-run]
+
+Dispatches repository event "${EVENT_TYPE}" to run PR review status sync once.
+`);
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv);
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  const result = await dispatchPrReviewStatusSync(options);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  EVENT_TYPE,
+  buildClientPayload,
+  dispatchPrReviewStatusSync,
+};

--- a/.github/scripts/dispatch-pr-review-status-sync.test.cjs
+++ b/.github/scripts/dispatch-pr-review-status-sync.test.cjs
@@ -1,0 +1,60 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const dispatch = require("./dispatch-pr-review-status-sync.cjs");
+
+test("buildClientPayload: review_resultを正規化する", () => {
+  const payload = dispatch.buildClientPayload({
+    prNumber: 275,
+    reviewResult: "Human Reviewへ進行可",
+  });
+  assert.equal(payload.pr_number, "275");
+  assert.equal(payload.review_result, "approve_for_human_review");
+});
+
+test("buildClientPayload: 無効なreview_resultは拒否する", () => {
+  assert.throws(
+    () => dispatch.buildClientPayload({ prNumber: 1, reviewResult: "invalid" }),
+    /Invalid review_result/,
+  );
+});
+
+test("dispatchPrReviewStatusSync: dry_runではAPIを呼ばない", async () => {
+  let called = false;
+  const result = await dispatch.dispatchPrReviewStatusSync({
+    owner: "o",
+    repo: "r",
+    prNumber: 10,
+    reviewResult: "approve_for_human_review",
+    token: "test-token",
+    dryRun: true,
+    fetchImpl: async () => {
+      called = true;
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.dryRun, true);
+  assert.equal(called, false);
+});
+
+test("dispatchPrReviewStatusSync: repository_dispatchをPOSTする", async () => {
+  const calls = [];
+  const result = await dispatch.dispatchPrReviewStatusSync({
+    repository: "o/r",
+    prNumber: 12,
+    reviewResult: "request_changes",
+    token: "test-token",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return { ok: true, status: 204, async text() { return ""; } };
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://api.github.com/repos/o/r/dispatches");
+  const body = JSON.parse(calls[0].options.body);
+  assert.equal(body.event_type, "ai_review_status_sync");
+  assert.equal(body.client_payload.pr_number, "12");
+  assert.equal(body.client_payload.review_result, "request_changes");
+});

--- a/.github/workflows/pr-review-status-sync.yml
+++ b/.github/workflows/pr-review-status-sync.yml
@@ -1,9 +1,9 @@
 name: PR review status sync
 
 on:
-  issue_comment:
+  repository_dispatch:
     types:
-      - created
+      - ai_review_status_sync
   pull_request_review:
     types:
       - submitted
@@ -26,8 +26,8 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: pr-review-status-sync-${{ github.event.issue.number || github.event.inputs.pr_number }}
-  cancel-in-progress: true
+  group: pr-review-status-sync-${{ github.event.client_payload.pr_number || github.event.inputs.pr_number || github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   sync-status:
@@ -194,11 +194,26 @@ jobs:
             let route = "";
 
             if (context.eventName === "workflow_dispatch") {
-              route = "dispatch";
+              route = "workflow_dispatch";
               prNumber = Number(context.payload.inputs.pr_number);
               reviewBody = String(context.payload.inputs.review_result || "");
               reviewResult = slack.normalizeReviewResult(reviewBody);
               if (!reviewResult) reviewResult = String(context.payload.inputs.review_result || "");
+            } else if (context.eventName === "repository_dispatch") {
+              route = "repository_dispatch";
+              const payload = context.payload.client_payload || {};
+              prNumber = Number(payload.pr_number);
+              reviewBody = String(payload.review_body || "");
+              reviewResult = slack.normalizeKnownReviewToken(payload.review_result || "");
+              if (!reviewResult) {
+                reviewResult = slack.normalizeReviewResult(String(payload.review_result || ""));
+              }
+              if (!prNumber || !reviewResult) {
+                core.setFailed(
+                  "client_payload requires pr_number and review_result (approve_for_human_review / request_changes / ...).",
+                );
+                return;
+              }
             } else if (context.eventName === "pull_request_review") {
               route = "human_review";
               const review = context.payload.review;
@@ -210,27 +225,8 @@ jobs:
               reviewResult = "request_changes";
               reviewBody = review.body || "";
             } else {
-              route = "ai_review_comment";
-              const issue = context.payload.issue;
-              if (!issue?.pull_request) {
-                core.info("Comment is not on a pull request; skipped.");
-                return;
-              }
-              const commentBody = context.payload.comment?.body || "";
-              if (slack.isAutomationBypassComment(commentBody)) {
-                return skipWithSummary("automation_comment", { PR: `#${issue.number}` });
-              }
-              if (!slack.isAiReviewResultComment(commentBody)) {
-                return skipWithSummary("not_ai_review_comment", { PR: `#${issue.number}` });
-              }
-              prNumber = issue.number;
-              reviewBody = commentBody;
-              const extracted = slack.extractReviewResultFromAiComment(commentBody);
-              if (!extracted.ok) {
-                core.setFailed(`Review Result parse failed: ${extracted.reason}`);
-                return;
-              }
-              reviewResult = extracted.value;
+              core.setFailed(`Unsupported event: ${context.eventName}`);
+              return;
             }
 
             const nextStatus = nextStatusFromReviewResult(reviewResult, reviewBody);

--- a/docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md
@@ -8,7 +8,7 @@
 | 項目              | 内容                                                            |
 | --------------- | ------------------------------------------------------------- |
 | 実装ファイル          | `.github/workflows/pr-review-status-sync.yml` |
-| 判定ロジック（単体テスト対象） | workflow内ロジックおよび `.github/scripts/slack-notify.cjs` |
+| 判定ロジック（単体テスト対象） | workflow内ロジック、`.github/scripts/slack-notify.cjs`、`.github/scripts/dispatch-pr-review-status-sync.cjs` |
 | Actions 表示名     | **PR review status sync**                      |
 | 正本              | 本ドキュメント（運用の数値・定数は実装 YAML と一致させる）                              |
 
@@ -22,7 +22,7 @@
 
 | 経路              | 概要                                                                     |
 | --------------- | ---------------------------------------------------------------------- |
-| AI Review 完了    | PR コメント上の **Review Result** に応じ、`Human Review` または `In Progress` へ遷移する |
+| AI Review 完了    | `repository_dispatch` の **Review Result** に応じ、`Human Review` または `In Progress` へ遷移する |
 | Human Review 指摘 | GitHub PR Review の `changes_requested` に応じ、`In Progress` へ遷移する         |
 
 
@@ -64,28 +64,41 @@ Status の正式値は [Projects運用ルール.md](../../00_共通/プロジェ
 
 | 項目                       | 内容                                                                               |
 | ------------------------ | -------------------------------------------------------------------------------- |
-| `on.issue_comment`       | `types: [created]` のみ。PR Issue コメント（AI Review 結果）を対象。**`edited` は対象外**（Slack thread marker 更新等による再実行を防ぐ） |
+| `on.repository_dispatch` | `types: [ai_review_status_sync]`。**AI Review 完了時の唯一の自動トリガ**（`/review-pr` または Harness から 1 回 dispatch） |
 | `on.pull_request_review` | `types: [submitted]`。`state: changes_requested` を Human 経路で処理                    |
-| `on.workflow_dispatch`   | 手動実行（検証・再実行用）。入力: PR 番号、Review Result 等                                    |
+| `on.workflow_dispatch`   | 手動再実行。入力: PR 番号、Review Result 等                                    |
+| `on.issue_comment`       | **使用しない**（Issue/PR コメントごとの Run 増殖・キャンセル連鎖を防ぐ） |
 | `permissions`            | `contents: read`、`issues: write`、`pull-requests: read`（PR・コメント参照）。Project API は `PROJECTS_TOKEN` |
-| `concurrency`            | `pr-review-status-sync-<PR番号>`（同一 PR の更新を直列化。**`cancel-in-progress: true`** で重複 Run を抑止）  |
+| `concurrency`            | `pr-review-status-sync-<PR番号>`（`client_payload.pr_number` / `inputs` / `pull_request.number`）。`cancel-in-progress: false` |
 
+### 3.1 AI Review 経路の起動（repository_dispatch）
 
-PR コメント経路では、**Pull Request** に紐づく Issue コメントのみを処理する（通常 Issue コメントはスキップ）。
+| 項目 | 内容 |
+| ---- | ---- |
+| イベント種別 | `ai_review_status_sync` |
+| 起動主体 | `/review-pr` 完了後の Agent、`node .github/scripts/dispatch-pr-review-status-sync.cjs`、または `gh api .../dispatches` |
+| Run 数 | **AI Review 1 回につき dispatch 1 回 → Workflow Run 1 回** |
 
-ジョブ条件 `if: github.event_name != 'issue_comment' || github.event.issue.pull_request` により、通常 Issue への `issue_comment` では **ワークフロー Run 自体を起動しない**（Issue metadata が付ける Branch 通知・Slack marker 等による無駄 Run を防ぐ）。
+`client_payload`（必須キー）:
 
-### 3.1 再実行ループ防止（必須）
+| キー | 型 | 説明 |
+| ---- | --- | ---- |
+| `pr_number` | string | 対象 PR 番号 |
+| `review_result` | string | `approve_for_human_review` / `request_changes` / `needs_human_decision` / `split_required` / `blocked`（または人間向けラベル） |
+| `review_body` | string | 任意。`needs_human_decision` で §22 `次Status` が `In Progress` のときの本文 |
 
-過去に、Status 更新後の **運用確認コメント** 本文へ `approve_for_human_review` 等を埋め込んだことで、`issue_comment` が連鎖しワークフローが多数回実行された。以下を実装の必須要件とする。
+PR 作成時の Status 更新（`AI Review`）は [PR作成時Status更新ワークフロー](./PR作成時Status更新ワークフロー仕様書.md)（`pr-created-status-and-slack.yml`）が担当し、本ワークフローは **起動しない**。
+
+Issue 作成時（metadata のコメント）でも本ワークフローは **起動しない**。
+
+### 3.2 再実行ループ防止（必須）
 
 | 対策 | 内容 |
 | ---- | ---- |
-| 運用コメントのバイパス | `Project Status更新意図:` で始まるコメント、Slack thread marker コメントは **AI 経路の対象外**（成功終了・処理なし） |
-| §6.1 の厳格適用 | AI Review 結果は [ai-review-comment.md](../../../prompts/templates/review/ai-review-comment.md) 形式（`## 1. レビュー結果` 等）のみ処理。全文部分一致は使わない |
-| 確認コメント | Status 更新後の PR コメントに **Review Result の enum 文字列を含めない** |
-| 冪等（§5.3） | GraphQL で現在 Status を読み、前提不一致・次 Status と同一なら更新・確認コメント・Slack を行わない |
-| 並行制御 | 同一 PR で `cancel-in-progress: true` |
+| `issue_comment` トリガ廃止 | コメント投稿で Workflow が連鎖起動しない |
+| dispatch 明示 | AI Review 完了は `repository_dispatch` のみ |
+| 確認コメント | Status 更新後の PR コメントに **Review Result enum を含めない**（記録用。トリガにはならない） |
+| 冪等（§5.3） | 現在 Status を読み、前提不一致・次 Status 同一なら更新・Slack をスキップ |
 
 ## 4. シークレット・定数
 
@@ -120,9 +133,9 @@ Status 列および遷移先（Project 上の表示名と一致させる。照�
 
 ## 5. Status 遷移表（実装の単一正本）
 
-### 5.1 AI Review 経路（PR コメント）
+### 5.1 AI Review 経路（repository_dispatch）
 
-PR コメントから **Review Result** を抽出し、次 Status を決定する。正本フォーマットは [ai-review-comment.md](../../../prompts/templates/review/ai-review-comment.md) §1・§22。
+`client_payload.review_result`（および任意の `review_body`）から次 Status を決定する。PR コメントの機械パースは行わない。PR コメント正本フォーマットは [ai-review-comment.md](../../../prompts/templates/review/ai-review-comment.md) §1・§22（人間・監査用。`/review-pr` が投稿する）。
 
 
 | Review Result                                                | 現在 Status（前提） | 次 Status              |
@@ -137,7 +150,7 @@ PR コメントから **Review Result** を抽出し、次 Status を決定す�
 
 `needs_human_decision` の自動化既定は `Human Review` とする。根拠は [review-definition.schema.md](../../../prompts/definitions/_schemas/review-definition.schema.md) の `status_policy.on_needs_human_decision` に合わせる。
 
-[AIレビュー運用設計書.md](../../00_共通/AIエージェント運用/AIレビュー運用設計書.md) §6 の「または In Progress」は、**PR コメントで `次Status` を明示した場合**に限り In Progress へ遷移する。
+[AIレビュー運用設計書.md](../../00_共通/AIエージェント運用/AIレビュー運用設計書.md) §6 の「または In Progress」は、**`client_payload.review_body`（または `workflow_dispatch` 入力）に `次Status` が `In Progress` と含まれる場合**に限り In Progress へ遷移する。
 
 ### 5.2 Human Review 経路（PR Review イベント）
 
@@ -164,73 +177,48 @@ Human Review で承認された場合、本ワークフローは Status を変�
 
 ### 5.4 AI 経路の致命的エラー（ジョブ失敗）
 
-§6.1 で **AI Review 結果コメントと判定した** あとに、次のいずれかが起きた場合は **Status を更新しない**（誤遷移防止）。かつ `**core.setFailed` でジョブ失敗** とし、原因解消後の再実行を必須とする（§9 参照）。
+§5.4 で **AI 経路** に、次のいずれかが起きた場合は **Status を更新しない**。かつ `core.setFailed` でジョブ失敗とする（§9 参照）。
 
 
 | 条件                           | 挙動    |
 | ---------------------------- | ----- |
-| Review Result を一意に抽出できない     | ジョブ失敗 |
+| `client_payload` に `pr_number` / `review_result` がない、または `review_result` が許容値でない | ジョブ失敗 |
 | 紐づく Task Issue を PR から解決できない | ジョブ失敗 |
 
 
 Human 経路では Review Result のパースは行わないため、本節は AI 経路のみに適用する。
 
-## 6. 機械判定: Review Result の抽出（AI 経路）
+## 6. 機械判定: Review Result（AI 経路）
 
-### 6.0 処理対象外コメント（バイパス）
+### 6.1 `client_payload` の正規化
 
-次の PR コメントは **AI 経路の入力に使わない**。ジョブは成功終了し、Summary に skipped 理由を記録する。
+1. `review_result` を `.github/scripts/slack-notify.cjs` の `normalizeKnownReviewToken` で正規化する（英語 enum または `Human Reviewへ進行可` 等の人間向けラベル）
+2. 正規化できない場合は §5.4 のパース失敗とする
 
-| 条件 | 例 |
-| ---- | --- |
-| 本文が `Project Status更新意図:` で始まる | 本ワークフローが Status 更新後に投稿する確認コメント |
-| Slack thread marker コメント | `<!-- slack-thread:v1 ... -->` を含むコメント |
+### 6.2 次Status の明示（needs_human_decision 用）
 
-### 6.1 AI Review コメントの識別
-
-§6.0 に該当しないうえで、次のいずれかを満たすコメントを AI Review 結果とみなす。
-
-- 本文に見出し `## 1. レビュー結果` または `## 22. Status更新意図` が含まれる
-- 表形式で `Review Result` 行が存在し、§1 の表セルから許容値が **1 件** 抽出できる
-
-Bot 投稿・人間投稿を問わない。フォーマットが [ai-review-comment.md](../../../prompts/templates/review/ai-review-comment.md) に従っていることを前提とする。
-
-§6.1 に該当しない PR コメント・通常 Issue コメントは **処理対象外** とし、ジョブは成功終了する（§9）。
-
-### 6.2 Review Result の抽出
-
-§6.1 に該当するコメントについて、次の優先順位で **1 件に定まる** 値を得る。定まらない場合は §5.4 のパース失敗とする。
-
-1. `Review Result | \`` 形式の表セル（§1 の表）
-2. `### レビュー結果分類` 直下の単一行
-
-**禁止**: コメント全文への `approve_for_human_review` 等の部分一致フォールバック（運用確認コメント・分類表の列挙と誤判定し、再実行ループの原因になる）。
-
-§6.1 に該当するが 1・2 で値が定まらない、または複数定まる場合は §5.4 のパース失敗とする。
-
-### 6.3 次Status の明示（needs_human_decision 用）
-
-`### 今回のStatus更新意図` 表の `次Status` 行を読む。
+`review_body`（未指定時は空文字）に対し、`次Status | \`In Progress\`` 形式が含まれるかを判定する（`statusFromReviewResult` と同じロジック）。
 
 
-| 次Status の記載           | 解釈                                      |
-| --------------------- | --------------------------------------- |
-| `In Progress`（大小無視）   | `needs_human_decision` でも In Progress へ |
-| 空欄・`Human Review`・未記載 | 既定どおり `Human Review` へ                  |
+| 条件 | 解釈 |
+| ---- | ---- |
+| `review_result` が `needs_human_decision` かつ `review_body` に In Progress 明示 | `In Progress` へ |
+| 上記以外の `needs_human_decision` | 既定どおり `Human Review` へ |
 
+### 6.3 紐づく Issue の特定
 
-### 6.4 紐づく Issue の特定
-
-§6.1 に該当するコメントについて、次を行う。
-
-1. PR コメントイベントから PR 番号を取得する
+1. `client_payload.pr_number` から PR を取得する
 2. PR 本文の `Related to #<n>` / `Closes #<n>` 等から Task Issue 番号を解決する（[Task Definition設計書.md](../../00_共通/AIエージェント運用/Task%20Definition設計書.md) §22・§39 を参照）
 3. 解決できない場合は §5.4 に従いジョブ失敗とする
+
+### 6.4 dispatch ヘルパー
+
+[`.github/scripts/dispatch-pr-review-status-sync.cjs`](../../../.github/scripts/dispatch-pr-review-status-sync.cjs) が `repository_dispatch` を 1 回 POST する。`/review-pr` §15.5 から利用する。
 
 ## 7. 処理概要
 
 1. イベント種別に応じて AI 経路または Human 経路を選択する
-2. `actions/checkout` で `.github/scripts/slack-notify.cjs` を読み込む（§6 識別・§5.3 照合・確認コメント文案）
+2. `actions/checkout` で `.github/scripts/slack-notify.cjs` を読み込む（§6 正規化・§5.3 照合・確認コメント文案）
 3. GraphQL で Project の **Status** フィールド ID と遷移先オプション ID を解決する
 4. 対象 Issue の Project item を特定し、**現在 Status** を `fieldValueByName(name: "Status")` で読む
 5. §5 の遷移表に従い次 Status を決定する（§5.3 のスキップ条件に該当すれば更新・確認コメント・Slack を行わず記録）
@@ -246,6 +234,7 @@ Bot 投稿・人間投稿を問わない。フォーマットが [ai-review-comm
 
 - `updateProjectV2ItemFieldValue` の `value` には `**singleSelectOptionId` のみ** を渡す
 - 対象は当該リポジトリの **Issue** に紐づく Project item のみ
+- **現在 Status の読取**は `node(id: $projectItemId) { ... on ProjectV2Item { fieldValueByName(name: "Status") { ... } } }` を用いる（`ProjectV2.item(id:)` は使用しない）
 
 ## 9. エラー・通知
 
@@ -256,22 +245,21 @@ Bot 投稿・人間投稿を問わない。フォーマットが [ai-review-comm
 | ----------------------------------------------------- | ----------------------------------------------- |
 | Project が取得できない                                       | `core.setFailed` でジョブ失敗                         |
 | `Status` フィールドまたは遷移先オプションが見つからない                      | `core.setFailed` でジョブ失敗                         |
-| AI 判定に非該当のコメント（§6.0 バイパス・§6.1 未満足）                   | ジョブ成功（Summary に skipped）                           |
-| 正当スキップのみで更新 0 件（§5.3）                                 | ジョブ成功（Summary に 0 件・skipped 内訳）                 |
-| AI Review 結果コメントと判定したが Review Result を一意に抽出できない（§5.4） | `core.setFailed`（Summary に PR 番号・失敗理由・コメント URL） |
-| AI Review 結果コメントと判定したが Task Issue を解決できない（§5.4）       | `core.setFailed`（Summary に PR 番号・失敗理由・コメント URL） |
+| 正当スキップのみで更新 0 件（§5.3）                                 | ジョブ成功（Summary に skipped 内訳）                 |
+| `client_payload` 不正（§5.4） | `core.setFailed` |
+| Task Issue を PR から解決できない（§5.4）       | `core.setFailed` |
 | 一部 item の更新で API 失敗                                   | 例外によりジョブ失敗（再実行で冪等に再試行可能）                        |
 
 
-ジョブ失敗時は、PR の Checks / Actions 一覧で検知できること。失敗を放置すると Projects の Status が `AI Review` のまま残るため、**コメント修正または `/review-pr` の再投稿のあと `workflow_dispatch` またはイベント再発火で再実行**する。
+ジョブ失敗時は、PR の Checks / Actions 一覧で検知できること。失敗を放置すると Projects の Status が `AI Review` のまま残るため、**`/review-pr` の dispatch 再実行**、または **`workflow_dispatch`** で再実行する。
 
 Slack通知に失敗しても、Projects Status の更新は取り消さない。通知失敗は workflow summary に記録する。
 
 ## 10. 運用上の必須事項
 
 - Project の Status に **AI Review** / **Human Review** / **In Progress** が存在し、表示名が [Projects運用ルール.md](../../00_共通/プロジェクト管理/Projects運用ルール.md) §9 と一致すること
-- `/review-pr` は PR コメントを [ai-review-comment.md](../../../prompts/templates/review/ai-review-comment.md) 形式で投稿すること（Review Result 行を省略しない）。**運用確認コメントと混同しない**
-- 本ワークフローが投稿する確認コメントを手動編集して Review Result 行を足さないこと（再実行ループの原因になる）
+- `/review-pr` は PR コメント投稿後に **必ず** `dispatch-pr-review-status-sync.cjs`（または同等の `repository_dispatch`）を **1 回** 実行すること
+- PR コメントは [ai-review-comment.md](../../../prompts/templates/review/ai-review-comment.md) 形式で投稿すること（人間・監査用。Status 同期のトリガには使わない）
 - PR 本文に Task Issue への参照（`Related to #<n>` 等）を含めること（§6.4）。不足時はワークフローが失敗する
 - 本ワークフローが **失敗（赤）** した場合は、Summary の PR・失敗理由を確認し、テンプレート・コメント・Issue 参照を修正してから再実行すること
 - `PROJECTS_TOKEN` には対象 Project の読み書きに必要なスコープを付与すること


### PR DESCRIPTION
Related to #265

## Summary

- `pr-review-status-sync` から `issue_comment` トリガを削除し、AI Review 完了は `repository_dispatch`（`ai_review_status_sync`）のみで 1 Run 起動する
- `.github/scripts/dispatch-pr-review-status-sync.cjs` を追加（`/review-pr` §15.5 から利用）
- `/review-pr` と仕様書を dispatch 前提に更新

## 背景

Issue/PR 作成時や AI Review コメント連鎖で Workflow Run が増殖・キャンセルされていた。PR 作成時の `AI Review` 遷移は `pr-created-status-and-slack.yml` が担当するため、本 Sync は AI Review 完了時のみ明示 dispatch する。

## Test plan

- [ ] `node --test .github/scripts/dispatch-pr-review-status-sync.test.cjs .github/scripts/slack-notify.test.cjs` が pass
- [ ] develop マージ後 E2E: Issue 作成で Sync Run **0**、PR 作成で **0**、`/review-pr` + dispatch で **1 Run**
- [ ] dispatch 忘れ時は `workflow_dispatch` で手動再実行可能
