### PR TITLE
chore: unify GitHub Actions run names with short slugs

### DIFF
--- a/.github/workflows/issue-metadata-project-branch.yml
+++ b/.github/workflows/issue-metadata-project-branch.yml
@@ -1,4 +1,6 @@
-name: Issue metadata project and branch sync
+name: Issue Metadata Sync
+
+run-name: issue-meta · ${{ github.event_name == 'issues' && format('issue-{0}', github.event.action) || 'manual' }} · #${{ github.event.issue.number || github.event.inputs.issue_number }}
 
 on:
   issues:

--- a/.github/workflows/pr-created-status-and-slack.yml
+++ b/.github/workflows/pr-created-status-and-slack.yml
@@ -1,4 +1,6 @@
-name: PR created status and Slack notification
+name: PR Created Status Sync
+
+run-name: pr-created · pr-open · PR #${{ github.event.pull_request.number || github.event.inputs.pr_number }}
 
 on:
   pull_request:

--- a/.github/workflows/pr-merged-done-and-slack.yml
+++ b/.github/workflows/pr-merged-done-and-slack.yml
@@ -1,4 +1,6 @@
-name: PR merged Done and Slack notification
+name: PR Merged Done Sync
+
+run-name: pr-merged · pr-closed · PR #${{ github.event.pull_request.number || github.event.inputs.pr_number }} · ${{ github.event_name == 'workflow_dispatch' && 'manual' || (github.event.pull_request.merged && 'merged' || 'closed') }}
 
 on:
   pull_request:

--- a/.github/workflows/pr-review-status-sync.yml
+++ b/.github/workflows/pr-review-status-sync.yml
@@ -1,4 +1,6 @@
-name: PR review status sync
+name: PR Review Status Sync
+
+run-name: status-sync · ${{ github.event_name == 'repository_dispatch' && 'dispatch' || github.event_name == 'pull_request_review' && 'human-review' || 'manual' }} · PR #${{ github.event.client_payload.pr_number || github.event.pull_request.number || github.event.inputs.pr_number }} · ${{ github.event.client_payload.review_result || github.event.inputs.review_result || github.event.review.state || 'n/a' }}
 
 on:
   repository_dispatch:
@@ -31,7 +33,6 @@ concurrency:
 
 jobs:
   sync-status:
-    if: github.event_name != 'issue_comment' || github.event.issue.pull_request
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/update-projects-status-by-planned-start.yml
+++ b/.github/workflows/update-projects-status-by-planned-start.yml
@@ -1,4 +1,6 @@
-name: Update project Status from Planned Start
+name: Planned Start Status Sync
+
+run-name: planned-start · ${{ github.event_name == 'schedule' && 'schedule' || 'manual' }}
 
 on:
   schedule:

--- a/docs/06_実装設計/github_actions/Issue作成時Projectフィールド同期ワークフロー.md
+++ b/docs/06_実装設計/github_actions/Issue作成時Projectフィールド同期ワークフロー.md
@@ -7,7 +7,8 @@
 | 項目 | 内容 |
 | ---- | ---- |
 | 実装ファイル | `.github/workflows/issue-metadata-project-branch.yml` |
-| Actions 表示名 | **Issue metadata project and branch sync** |
+| Actions 表示名 | **Issue Metadata Sync** |
+| Run 名（一覧） | `issue-meta · issue-{opened\|edited} · #n` |
 | 正本 | 本ドキュメント（運用の数値・定数は実装 YAML と一致させる） |
 
 ## 2. 目的と対象外

--- a/docs/06_実装設計/github_actions/Issue同期とブランチ作成ワークフロー.md
+++ b/docs/06_実装設計/github_actions/Issue同期とブランチ作成ワークフロー.md
@@ -18,7 +18,7 @@ Branch 作成抑止（no-branch）の**正本**は [Issue運用ルール](../../
 
 本ワークフローは **GitHub Actions** を利用して実装する。
 
-実装ファイル：`.github/workflows/issue-metadata-project-branch.yml`（表示名: **Issue metadata project and branch sync**）
+実装ファイル：`.github/workflows/issue-metadata-project-branch.yml`（表示名: **Issue Metadata Sync**、Run 名: `issue-meta · …`）
 
 Project の **Status / Phase / Priority / Area / Planned Start / Due Date / Actual Start** は、同workflowがIssue本文およびBranch作成結果から同期する。フィールド一覧は [Projects運用ルール](../Projects運用ルール.md) を参照。
 

--- a/docs/06_実装設計/github_actions/PR merge時Status更新・Slack通知ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PR merge時Status更新・Slack通知ワークフロー仕様書.md
@@ -12,7 +12,8 @@ Task Issueの完了制御は、PR本文の自動closeキーワードだけに依
 | ---- | ---- |
 | 実装ファイル | `.github/workflows/pr-merged-done-and-slack.yml` |
 | 共通script | `.github/scripts/slack-notify.cjs` |
-| Actions表示名 | `PR merged Done and Slack notification` |
+| Actions表示名 | `PR Merged Done Sync` |
+| Run 名（一覧） | `pr-merged · pr-closed · PR #n · {merged\|closed\|manual}` |
 
 ## 3. トリガー
 

--- a/docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md
@@ -9,7 +9,8 @@
 | --------------- | ------------------------------------------------------------- |
 | 実装ファイル          | `.github/workflows/pr-review-status-sync.yml` |
 | 判定ロジック（単体テスト対象） | workflow内ロジック、`.github/scripts/slack-notify.cjs`、`.github/scripts/dispatch-pr-review-status-sync.cjs` |
-| Actions 表示名     | **PR review status sync**                      |
+| Actions 表示名     | **PR Review Status Sync**                      |
+| Run 名（一覧）     | `status-sync · {dispatch\|human-review\|manual} · PR #n · {review_result\|state}` |
 | 正本              | 本ドキュメント（運用の数値・定数は実装 YAML と一致させる）                              |
 
 

--- a/docs/06_実装設計/github_actions/PR作成時Status更新・Slack通知ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PR作成時Status更新・Slack通知ワークフロー仕様書.md
@@ -13,7 +13,8 @@ Slack通知の文面・通知レベルは [Slack通知運用設計書](../../00_
 | ---- | ---- |
 | 実装ファイル | `.github/workflows/pr-created-status-and-slack.yml` |
 | 共通script | `.github/scripts/slack-notify.cjs` |
-| Actions表示名 | `PR created status and Slack notification` |
+| Actions表示名 | `PR Created Status Sync` |
+| Run 名（一覧） | `pr-created · pr-open · PR #n` |
 
 ## 3. トリガー
 

--- a/docs/06_実装設計/github_actions/Planned Startに基づくStatus自動更新ワークフロー.md
+++ b/docs/06_実装設計/github_actions/Planned Startに基づくStatus自動更新ワークフロー.md
@@ -8,7 +8,8 @@
 | ---- | ---- |
 | 実装ファイル | `.github/workflows/update-projects-status-by-planned-start.yml` |
 | 判定ロジック（単体テスト対象） | `.github/scripts/planned-start-status-policy.cjs` |
-| Actions 表示名 | **Update project Status from Planned Start** |
+| Actions 表示名 | **Planned Start Status Sync** |
+| Run 名（一覧） | `planned-start · {schedule\|manual}` |
 | 正本 | 本ドキュメント（運用の数値・定数は実装 YAML と一致させる） |
 
 ## 2. 目的と対象外


### PR DESCRIPTION
Related to #265

## Summary

- Status 系 workflow 5 本に `run-name` を追加（短 slug: `status-sync` / `issue-meta` / `pr-created` / `pr-merged` / `planned-start`）
- workflow `name:` を Title Case に統一
- 仕様書の Actions 表示名・Run 名形式を更新
- `pr-review-status-sync` の不要な `issue_comment` 用 job `if` を削除

## Test plan

- [ ] PR merge 後 E2E: Issue 作成 → `issue-meta · issue-opened · #n`
- [ ] PR 作成 → `pr-created · pr-open · PR #n`
- [ ] dispatch → `status-sync · dispatch · PR #n · approve_for_human_review`
