### PR TITLE
fix: quote run-name YAML to preserve issue/PR numbers

### DIFF
--- a/.github/workflows/issue-metadata-project-branch.yml
+++ b/.github/workflows/issue-metadata-project-branch.yml
@@ -1,6 +1,6 @@
 name: Issue Metadata Sync
 
-run-name: issue-meta · ${{ github.event_name == 'issues' && format('issue-{0}', github.event.action) || 'manual' }} · #${{ github.event.issue.number || github.event.inputs.issue_number }}
+run-name: "issue-meta · ${{ github.event_name == 'issues' && format('issue-{0}', github.event.action) || 'manual' }} · #${{ github.event.issue.number || github.event.inputs.issue_number }}"
 
 on:
   issues:

--- a/.github/workflows/pr-created-status-and-slack.yml
+++ b/.github/workflows/pr-created-status-and-slack.yml
@@ -1,6 +1,6 @@
 name: PR Created Status Sync
 
-run-name: pr-created · pr-open · PR #${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+run-name: "pr-created · pr-open · PR #${{ github.event.pull_request.number || github.event.inputs.pr_number }}"
 
 on:
   pull_request:

--- a/.github/workflows/pr-merged-done-and-slack.yml
+++ b/.github/workflows/pr-merged-done-and-slack.yml
@@ -1,6 +1,6 @@
 name: PR Merged Done Sync
 
-run-name: pr-merged · pr-closed · PR #${{ github.event.pull_request.number || github.event.inputs.pr_number }} · ${{ github.event_name == 'workflow_dispatch' && 'manual' || (github.event.pull_request.merged && 'merged' || 'closed') }}
+run-name: "pr-merged · pr-closed · PR #${{ github.event.pull_request.number || github.event.inputs.pr_number }} · ${{ github.event_name == 'workflow_dispatch' && 'manual' || (github.event.pull_request.merged && 'merged' || 'closed') }}"
 
 on:
   pull_request:

--- a/.github/workflows/pr-review-status-sync.yml
+++ b/.github/workflows/pr-review-status-sync.yml
@@ -1,6 +1,6 @@
 name: PR Review Status Sync
 
-run-name: status-sync · ${{ github.event_name == 'repository_dispatch' && 'dispatch' || github.event_name == 'pull_request_review' && 'human-review' || 'manual' }} · PR #${{ github.event.client_payload.pr_number || github.event.pull_request.number || github.event.inputs.pr_number }} · ${{ github.event.client_payload.review_result || github.event.inputs.review_result || github.event.review.state || 'n/a' }}
+run-name: "status-sync · ${{ github.event_name == 'repository_dispatch' && 'dispatch' || github.event_name == 'pull_request_review' && 'human-review' || 'manual' }} · PR #${{ github.event.client_payload.pr_number || github.event.pull_request.number || github.event.inputs.pr_number }} · ${{ github.event.client_payload.review_result || github.event.inputs.review_result || github.event.review.state || 'n/a' }}"
 
 on:
   repository_dispatch:

--- a/.github/workflows/update-projects-status-by-planned-start.yml
+++ b/.github/workflows/update-projects-status-by-planned-start.yml
@@ -1,6 +1,6 @@
 name: Planned Start Status Sync
 
-run-name: planned-start · ${{ github.event_name == 'schedule' && 'schedule' || 'manual' }}
+run-name: "planned-start · ${{ github.event_name == 'schedule' && 'schedule' || 'manual' }}"
 
 on:
   schedule:


### PR DESCRIPTION
Related to #265

run-name 内の \#\ が YAML コメントとして切れていたため、文字列全体を引用符で囲む。

Made with [Cursor](https://cursor.com)