### PR TITLE
feat: publish AI review comment and status dispatch in one command

### DIFF
--- a/.cursor/commands/review-pr.md
+++ b/.cursor/commands/review-pr.md
@@ -456,13 +456,48 @@ AIレビュー結果をPRへ記録する。
 
 PR コメントは [ai-review-comment.md](../../prompts/templates/review/ai-review-comment.md) 形式とする。特に §1 の `Review Result` 行と §22 の `次Status` を省略しない。
 
+**dispatch 忘れ防止**: コメント投稿と Status 同期 dispatch は **1 コマンド** で行う（§15.5）。分離実行は recovery 時のみ。
+
 ---
 
-### 15.5 Projects Status 同期を起動する（必須）
+### 15.5 Projects Status 同期を起動する（必須・1コマンド）
 
-PR コメント投稿後、**必ず 1 回** [PR review status sync](../../.github/workflows/pr-review-status-sync.yml) を `repository_dispatch` で起動する。
-
+PR コメント投稿と `repository_dispatch` は **必ず同一コマンド** で実行する。  
 Status 更新はコメント投稿では自動検知しない。dispatch 忘れは Projects Status が `AI Review` のまま残る。
+
+**推奨（コメント + dispatch を原子的に実行）:**
+
+```bash
+node .github/scripts/publish-ai-review-and-dispatch.cjs \
+  --repository <owner>/<repo> \
+  --pr <PR番号> \
+  --comment-file /path/to/ai-review-comment.md
+```
+
+`Review Result` はコメント §1 から自動抽出される。`needs_human_decision` で §22 `次Status` が `In Progress` のときは、コメント全文を `review_body` として dispatch に渡す。
+
+**完了確認（dispatch 忘れチェック）:**
+
+```bash
+node .github/scripts/publish-ai-review-and-dispatch.cjs \
+  --repository <owner>/<repo> \
+  --pr <PR番号> \
+  --verify
+```
+
+`ok: false` かつ `reason: dispatch_missing` の場合は、出力された `recovery_command` を実行する。
+
+**Recovery（コメント投稿済み・dispatch のみ再実行）:**
+
+```bash
+node .github/scripts/publish-ai-review-and-dispatch.cjs \
+  --repository <owner>/<repo> \
+  --pr <PR番号> \
+  --comment-file /path/to/ai-review-comment.md \
+  --dispatch-only
+```
+
+**低レベル API（非推奨・分離実行）:**
 
 ```bash
 node .github/scripts/dispatch-pr-review-status-sync.cjs \
@@ -471,26 +506,9 @@ node .github/scripts/dispatch-pr-review-status-sync.cjs \
   --review-result <approve_for_human_review|request_changes|needs_human_decision|split_required|blocked>
 ```
 
-`needs_human_decision` で PR コメント §22 の `次Status` が `In Progress` のときは、コメント本文を渡す。
+`needs_human_decision` で PR コメント §22 の `次Status` が `In Progress` のときは `--review-body-file` を付ける。
 
-```bash
-node .github/scripts/dispatch-pr-review-status-sync.cjs \
-  --repository <owner>/<repo> \
-  --pr <PR番号> \
-  --review-result needs_human_decision \
-  --review-body-file /path/to/ai-review-comment.md
-```
-
-代替（`gh` のみ）:
-
-```bash
-gh api repos/<owner>/<repo>/dispatches \
-  -f event_type=ai_review_status_sync \
-  -f "client_payload[pr_number]=<PR番号>" \
-  -f "client_payload[review_result]=<Review Result>"
-```
-
-dispatch が失敗した場合は、PR コメントは残るが Status は更新されない。ログを確認し、修正後に `workflow_dispatch` または dispatch を再実行する。
+dispatch が失敗した場合は、PR コメントは残るが Status は更新されない。`--dispatch-only` または `workflow_dispatch` で再実行する。
 
 ---
 
@@ -559,7 +577,7 @@ Status更新は、Commandが直接確定するのではなく、GitHub Actions�
 - 横断影響が確認されている
 - 前段成果物の修正要否が確認されている
 - PRへAIレビュー結果が記録されている
-- `repository_dispatch`（`ai_review_status_sync`）を 1 回起動している
+- `publish-ai-review-and-dispatch.cjs` で **コメント投稿 + repository_dispatch を 1 回** 実行している（または `--verify` で dispatch 済みを確認済み）
 - 修正要否が明確である
 - Human Reviewへ進めてよいか判断できる
 - 指摘がある場合、修正対象が明確である
@@ -629,7 +647,7 @@ Status更新は、Commandが直接確定するのではなく、GitHub Actions�
 | split_required           | `In Progress`                       |
 | blocked                  | `In Progress`                       |
 
-Status更新は、Commandが直接確定するのではなく、[PRレビュー完了時Status更新ワークフロー仕様書](../../docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md) が実施する。`/review-pr` は §15.5 の **repository_dispatch を 1 回** 呼び出し、更新意図を PR コメントにも明記する。
+Status更新は、Commandが直接確定するのではなく、[PRレビュー完了時Status更新ワークフロー仕様書](../../docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md) が実施する。`/review-pr` は §15.5 の **`publish-ai-review-and-dispatch.cjs` を 1 回** 呼び出し（コメント + dispatch）、更新意図を PR コメントにも明記する。
 
 ---
 

--- a/.github/scripts/publish-ai-review-and-dispatch.cjs
+++ b/.github/scripts/publish-ai-review-and-dispatch.cjs
@@ -1,0 +1,437 @@
+"use strict";
+
+const fs = require("fs");
+const slack = require("./slack-notify.cjs");
+const dispatch = require("./dispatch-pr-review-status-sync.cjs");
+
+const STATUS_SYNC_WORKFLOW_FILE = "pr-review-status-sync.yml";
+const DISPATCH_RUN_TITLE_RE = /status-sync · dispatch · PR #(\d+)/;
+
+function nonEmpty(value) {
+  return String(value || "").trim();
+}
+
+function resolveRepository({ owner, repo, repository }) {
+  if (owner && repo) return { owner: nonEmpty(owner), repo: nonEmpty(repo) };
+  const full = nonEmpty(repository) || nonEmpty(process.env.GITHUB_REPOSITORY);
+  if (!full || !full.includes("/")) {
+    throw new Error("repository is required (--owner/--repo or GITHUB_REPOSITORY)");
+  }
+  const [resolvedOwner, resolvedRepo] = full.split("/", 2);
+  return { owner: resolvedOwner, repo: resolvedRepo };
+}
+
+function readCommentBody({ commentBody, commentFile }) {
+  if (nonEmpty(commentBody)) return commentBody;
+  if (nonEmpty(commentFile)) return fs.readFileSync(commentFile, "utf8");
+  throw new Error("comment body is required (--comment-body or --comment-file)");
+}
+
+function resolveReviewResult({ commentBody, reviewResultOverride }) {
+  const override = nonEmpty(reviewResultOverride);
+  if (override) {
+    const normalized = slack.normalizeKnownReviewToken(reviewResultOverride);
+    if (!normalized) {
+      throw new Error(`Invalid review_result override: ${reviewResultOverride}`);
+    }
+    return normalized;
+  }
+  const extracted = slack.extractReviewResultFromAiComment(commentBody);
+  if (!extracted.ok) {
+    const reason =
+      extracted.reason === "not_ai_review_comment"
+        ? "Comment is not ai-review-comment format (§1 Review Result required)."
+        : extracted.reason === "ambiguous_review_result"
+          ? "Review Result is ambiguous in comment."
+          : "Review Result not found in comment.";
+    throw new Error(reason);
+  }
+  return extracted.value;
+}
+
+function authHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "Content-Type": "application/json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function postPullRequestComment({
+  owner,
+  repo,
+  prNumber,
+  body,
+  token,
+  dryRun,
+  fetchImpl,
+}) {
+  const pr = Number(prNumber);
+  if (!Number.isInteger(pr) || pr <= 0) {
+    throw new Error(`Invalid pr_number: ${prNumber}`);
+  }
+  if (dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      html_url: `https://github.com/${owner}/${repo}/pull/${pr}#dry-run-comment`,
+    };
+  }
+  const send = fetchImpl || global.fetch;
+  if (typeof send !== "function") {
+    throw new Error("fetch is unavailable");
+  }
+  const response = await send(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${pr}/comments`,
+    {
+      method: "POST",
+      headers: authHeaders(token),
+      body: JSON.stringify({ body }),
+    },
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Failed to post PR comment: HTTP ${response.status} ${text}`.trim());
+  }
+  const data = await response.json();
+  return { ok: true, html_url: data.html_url || "", id: data.id };
+}
+
+function buildRecoveryCommand({ owner, repo, prNumber, reviewResult, commentFile }) {
+  const repoArg = `--repository ${owner}/${repo}`;
+  const parts = [
+    "node .github/scripts/publish-ai-review-and-dispatch.cjs",
+    repoArg,
+    `--pr ${prNumber}`,
+    `--review-result ${reviewResult}`,
+    "--dispatch-only",
+  ];
+  if (commentFile) parts.push(`--comment-file ${commentFile}`);
+  return parts.join(" \\\n  ");
+}
+
+async function publishAiReviewAndDispatch({
+  owner,
+  repo,
+  repository,
+  prNumber,
+  commentBody,
+  commentFile,
+  reviewResult,
+  token,
+  dryRun,
+  dispatchOnly,
+  fetchImpl,
+}) {
+  const resolved = resolveRepository({ owner, repo, repository });
+  const authToken = nonEmpty(token) || nonEmpty(process.env.GITHUB_TOKEN) || nonEmpty(process.env.GH_TOKEN);
+  if (!authToken) {
+    throw new Error("GITHUB_TOKEN or GH_TOKEN is required");
+  }
+
+  const body = readCommentBody({ commentBody, commentFile });
+  const normalizedResult = resolveReviewResult({ commentBody: body, reviewResultOverride: reviewResult });
+
+  let commentResult = null;
+  if (!dispatchOnly) {
+    if (!slack.isAiReviewResultComment(body)) {
+      throw new Error("Comment is not ai-review-comment format. Use prompts/templates/review/ai-review-comment.md.");
+    }
+    commentResult = await postPullRequestComment({
+      owner: resolved.owner,
+      repo: resolved.repo,
+      prNumber,
+      body,
+      token: authToken,
+      dryRun,
+      fetchImpl,
+    });
+  }
+
+  try {
+    const dispatchResult = await dispatch.dispatchPrReviewStatusSync({
+      owner: resolved.owner,
+      repo: resolved.repo,
+      prNumber,
+      reviewResult: normalizedResult,
+      reviewBody: body,
+      token: authToken,
+      dryRun,
+      fetchImpl,
+    });
+    return {
+      ok: true,
+      owner: resolved.owner,
+      repo: resolved.repo,
+      pr_number: String(prNumber),
+      review_result: normalizedResult,
+      comment: commentResult,
+      dispatch: dispatchResult,
+      dispatch_only: Boolean(dispatchOnly),
+    };
+  } catch (error) {
+    if (commentResult && !dryRun) {
+      error.recoveryCommand = buildRecoveryCommand({
+        owner: resolved.owner,
+        repo: resolved.repo,
+        prNumber,
+        reviewResult: normalizedResult,
+        commentFile,
+      });
+      error.message = `${error.message}\n\nPR comment was posted but dispatch failed. Re-run dispatch only:\n${error.recoveryCommand}`;
+    }
+    throw error;
+  }
+}
+
+async function listIssueComments({ owner, repo, prNumber, token, fetchImpl }) {
+  const send = fetchImpl || global.fetch;
+  const response = await send(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/comments?per_page=100`,
+    { headers: authHeaders(token) },
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Failed to list PR comments: HTTP ${response.status} ${text}`.trim());
+  }
+  return response.json();
+}
+
+async function listStatusSyncDispatchRuns({ owner, repo, token, fetchImpl, perPage = 30 }) {
+  const send = fetchImpl || global.fetch;
+  const response = await send(
+    `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${STATUS_SYNC_WORKFLOW_FILE}/runs?event=repository_dispatch&per_page=${perPage}`,
+    { headers: authHeaders(token) },
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Failed to list workflow runs: HTTP ${response.status} ${text}`.trim());
+  }
+  const data = await response.json();
+  return data.workflow_runs || [];
+}
+
+function findLatestAiReviewComment(comments) {
+  const sorted = [...(comments || [])].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+  return sorted.find((comment) => slack.isAiReviewResultComment(comment.body || ""));
+}
+
+function findDispatchRunAfterComment({ runs, prNumber, sinceIso }) {
+  const since = new Date(sinceIso).getTime();
+  const pr = String(prNumber);
+  return (runs || []).find((run) => {
+    const title = String(run.display_title || run.name || "");
+    const match = DISPATCH_RUN_TITLE_RE.exec(title);
+    if (!match || match[1] !== pr) return false;
+    const created = new Date(run.created_at).getTime();
+    if (Number.isNaN(created) || created < since) return false;
+    return run.status === "completed" && run.conclusion === "success";
+  });
+}
+
+async function verifyAiReviewDispatch({
+  owner,
+  repo,
+  repository,
+  prNumber,
+  token,
+  fetchImpl,
+  listComments = listIssueComments,
+  listRuns = listStatusSyncDispatchRuns,
+}) {
+  const resolved = resolveRepository({ owner, repo, repository });
+  const authToken = nonEmpty(token) || nonEmpty(process.env.GITHUB_TOKEN) || nonEmpty(process.env.GH_TOKEN);
+  if (!authToken) {
+    throw new Error("GITHUB_TOKEN or GH_TOKEN is required");
+  }
+
+  const comments = await listComments({
+    owner: resolved.owner,
+    repo: resolved.repo,
+    prNumber,
+    token: authToken,
+    fetchImpl,
+  });
+  const latestAiComment = findLatestAiReviewComment(comments);
+  if (!latestAiComment) {
+    return {
+      ok: false,
+      reason: "no_ai_review_comment",
+      message: "No AI Review comment found on PR.",
+    };
+  }
+
+  const extracted = slack.extractReviewResultFromAiComment(latestAiComment.body || "");
+  const runs = await listRuns({
+    owner: resolved.owner,
+    repo: resolved.repo,
+    token: authToken,
+    fetchImpl,
+  });
+  const matchedRun = findDispatchRunAfterComment({
+    runs,
+    prNumber,
+    sinceIso: latestAiComment.created_at,
+  });
+
+  if (!matchedRun) {
+    const recovery = buildRecoveryCommand({
+      owner: resolved.owner,
+      repo: resolved.repo,
+      prNumber,
+      reviewResult: extracted.ok ? extracted.value : "<review_result>",
+    });
+    return {
+      ok: false,
+      reason: "dispatch_missing",
+      message: "AI Review comment exists but no successful status-sync dispatch run found after it.",
+      latest_ai_review_comment_url: latestAiComment.html_url || "",
+      latest_ai_review_comment_at: latestAiComment.created_at || "",
+      recovery_command: recovery,
+    };
+  }
+
+  return {
+    ok: true,
+    pr_number: String(prNumber),
+    latest_ai_review_comment_url: latestAiComment.html_url || "",
+    latest_ai_review_comment_at: latestAiComment.created_at || "",
+    dispatch_run_id: matchedRun.id,
+    dispatch_run_url: matchedRun.html_url || "",
+    dispatch_run_title: matchedRun.display_title || matchedRun.name || "",
+    review_result: extracted.ok ? extracted.value : "",
+  };
+}
+
+function parseCliArgs(argv) {
+  const args = argv.slice(2);
+  const options = {
+    owner: "",
+    repo: "",
+    repository: "",
+    prNumber: "",
+    commentBody: "",
+    commentFile: "",
+    reviewResult: "",
+    dryRun: false,
+    dispatchOnly: false,
+    verifyOnly: false,
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--dispatch-only") {
+      options.dispatchOnly = true;
+      continue;
+    }
+    if (arg === "--verify") {
+      options.verifyOnly = true;
+      continue;
+    }
+    if (arg === "--owner") {
+      options.owner = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repository" || arg === "-R") {
+      options.repository = args[++i] || "";
+      continue;
+    }
+    if (arg === "--pr" || arg === "--pr-number") {
+      options.prNumber = args[++i] || "";
+      continue;
+    }
+    if (arg === "--review-result") {
+      options.reviewResult = args[++i] || "";
+      continue;
+    }
+    if (arg === "--comment-body") {
+      options.commentBody = args[++i] || "";
+      continue;
+    }
+    if (arg === "--comment-file") {
+      options.commentFile = args[++i] || "";
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  # Post AI Review comment and dispatch status-sync (recommended)
+  node .github/scripts/publish-ai-review-and-dispatch.cjs \\
+    --repository owner/repo --pr <number> --comment-file path/to/ai-review-comment.md
+
+  # Recovery: dispatch only (comment already posted)
+  node .github/scripts/publish-ai-review-and-dispatch.cjs \\
+    --repository owner/repo --pr <number> --review-result approve_for_human_review \\
+    --comment-file path/to/ai-review-comment.md --dispatch-only
+
+  # Verify dispatch was not forgotten
+  node .github/scripts/publish-ai-review-and-dispatch.cjs \\
+    --repository owner/repo --pr <number> --verify
+`);
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv);
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  if (!options.prNumber) {
+    throw new Error("--pr is required");
+  }
+
+  if (options.verifyOnly) {
+    const result = await verifyAiReviewDispatch(options);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (options.dispatchOnly) {
+    if (!options.reviewResult && !options.commentFile && !options.commentBody) {
+      throw new Error("--dispatch-only requires --review-result or --comment-file");
+    }
+  } else if (!options.commentFile && !options.commentBody) {
+    throw new Error("--comment-file or --comment-body is required (unless --dispatch-only or --verify)");
+  }
+
+  const result = await publishAiReviewAndDispatch(options);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  STATUS_SYNC_WORKFLOW_FILE,
+  DISPATCH_RUN_TITLE_RE,
+  resolveReviewResult,
+  postPullRequestComment,
+  publishAiReviewAndDispatch,
+  verifyAiReviewDispatch,
+  findLatestAiReviewComment,
+  findDispatchRunAfterComment,
+  buildRecoveryCommand,
+};

--- a/.github/scripts/publish-ai-review-and-dispatch.test.cjs
+++ b/.github/scripts/publish-ai-review-and-dispatch.test.cjs
@@ -1,0 +1,170 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const publish = require("./publish-ai-review-and-dispatch.cjs");
+
+const SAMPLE_COMMENT = `# AI Review Result
+
+## 1. レビュー結果
+
+| 項目          | 内容                       |
+| ------------- | -------------------------- |
+| Review Result | \`approve_for_human_review\` |
+| 対象PR        | \`#10\`                    |
+
+## 22. Status更新意図
+
+| 項目       | 内容           |
+| ---------- | -------------- |
+| 次Status   | \`Human Review\` |
+`;
+
+test("resolveReviewResult: コメントからReview Resultを抽出する", () => {
+  const value = publish.resolveReviewResult({ commentBody: SAMPLE_COMMENT });
+  assert.equal(value, "approve_for_human_review");
+});
+
+test("resolveReviewResult: overrideが優先される", () => {
+  const value = publish.resolveReviewResult({
+    commentBody: SAMPLE_COMMENT,
+    reviewResultOverride: "request_changes",
+  });
+  assert.equal(value, "request_changes");
+});
+
+test("publishAiReviewAndDispatch: dry_runではAPIを呼ばない", async () => {
+  let called = 0;
+  const result = await publish.publishAiReviewAndDispatch({
+    repository: "o/r",
+    prNumber: 10,
+    commentBody: SAMPLE_COMMENT,
+    token: "t",
+    dryRun: true,
+    fetchImpl: async () => {
+      called += 1;
+      return { ok: true, json: async () => ({}) };
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.review_result, "approve_for_human_review");
+  assert.equal(called, 0);
+});
+
+test("publishAiReviewAndDispatch: コメント投稿後にdispatchする", async () => {
+  const calls = [];
+  const result = await publish.publishAiReviewAndDispatch({
+    repository: "o/r",
+    prNumber: 10,
+    commentBody: SAMPLE_COMMENT,
+    token: "t",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, method: options.method });
+      if (url.includes("/issues/10/comments") && options.method === "POST") {
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({ html_url: "https://example.com/comment/1", id: 1 }),
+        };
+      }
+      if (url.includes("/dispatches")) {
+        return { ok: true, status: 204, async text() { return ""; } };
+      }
+      throw new Error(`unexpected url: ${url}`);
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 2);
+  assert.match(calls[0].url, /issues\/10\/comments$/);
+  assert.match(calls[1].url, /dispatches$/);
+});
+
+test("publishAiReviewAndDispatch: dispatch失敗時にrecoveryCommandを付与する", async () => {
+  await assert.rejects(
+    () =>
+      publish.publishAiReviewAndDispatch({
+        repository: "o/r",
+        prNumber: 10,
+        commentBody: SAMPLE_COMMENT,
+        commentFile: "/tmp/ai-review.md",
+        token: "t",
+        fetchImpl: async (url, options) => {
+          if (url.includes("/issues/10/comments")) {
+            return {
+              ok: true,
+              status: 201,
+              json: async () => ({ html_url: "https://example.com/comment/1", id: 1 }),
+            };
+          }
+          if (url.includes("/dispatches")) {
+            return { ok: false, status: 403, text: async () => "forbidden" };
+          }
+          throw new Error(url);
+        },
+      }),
+    (error) => {
+      assert.match(error.message, /dispatch failed/i);
+      assert.match(error.recoveryCommand, /--dispatch-only/);
+      assert.match(error.recoveryCommand, /--comment-file/);
+      return true;
+    },
+  );
+});
+
+test("verifyAiReviewDispatch: dispatch済みならok", async () => {
+  const result = await publish.verifyAiReviewDispatch({
+    repository: "o/r",
+    prNumber: 10,
+    token: "t",
+    listComments: async () => [
+      {
+        body: SAMPLE_COMMENT,
+        created_at: "2026-05-30T00:00:00Z",
+        html_url: "https://example.com/c/1",
+      },
+    ],
+    listRuns: async () => [
+      {
+        id: 99,
+        display_title: "status-sync · dispatch · PR #10 · approve_for_human_review",
+        created_at: "2026-05-30T00:00:05Z",
+        status: "completed",
+        conclusion: "success",
+        html_url: "https://example.com/run/99",
+      },
+    ],
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.dispatch_run_id, 99);
+});
+
+test("verifyAiReviewDispatch: コメントのみでdispatch欠落", async () => {
+  const result = await publish.verifyAiReviewDispatch({
+    repository: "o/r",
+    prNumber: 10,
+    token: "t",
+    listComments: async () => [
+      {
+        body: SAMPLE_COMMENT,
+        created_at: "2026-05-30T00:00:00Z",
+        html_url: "https://example.com/c/1",
+      },
+    ],
+    listRuns: async () => [],
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "dispatch_missing");
+  assert.match(result.recovery_command, /--dispatch-only/);
+});
+
+test("verifyAiReviewDispatch: AI Reviewコメントなし", async () => {
+  const result = await publish.verifyAiReviewDispatch({
+    repository: "o/r",
+    prNumber: 10,
+    token: "t",
+    listComments: async () => [{ body: "hello", created_at: "2026-05-30T00:00:00Z" }],
+    listRuns: async () => [],
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "no_ai_review_comment");
+});

--- a/docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md
@@ -8,7 +8,7 @@
 | 項目              | 内容                                                            |
 | --------------- | ------------------------------------------------------------- |
 | 実装ファイル          | `.github/workflows/pr-review-status-sync.yml` |
-| 判定ロジック（単体テスト対象） | workflow内ロジック、`.github/scripts/slack-notify.cjs`、`.github/scripts/dispatch-pr-review-status-sync.cjs` |
+| 判定ロジック（単体テスト対象） | workflow内ロジック、`.github/scripts/slack-notify.cjs`、`.github/scripts/dispatch-pr-review-status-sync.cjs`、`.github/scripts/publish-ai-review-and-dispatch.cjs` |
 | Actions 表示名     | **PR Review Status Sync**                      |
 | Run 名（一覧）     | `status-sync · {dispatch\|human-review\|manual} · PR #n · {review_result\|state}` |
 | 正本              | 本ドキュメント（運用の数値・定数は実装 YAML と一致させる）                              |
@@ -77,7 +77,7 @@ Status の正式値は [Projects運用ルール.md](../../00_共通/プロジェ
 | 項目 | 内容 |
 | ---- | ---- |
 | イベント種別 | `ai_review_status_sync` |
-| 起動主体 | `/review-pr` 完了後の Agent、`node .github/scripts/dispatch-pr-review-status-sync.cjs`、または `gh api .../dispatches` |
+| 起動主体 | `/review-pr` 完了後の Agent（**`publish-ai-review-and-dispatch.cjs` 推奨**）、`dispatch-pr-review-status-sync.cjs`、または `gh api .../dispatches` |
 | Run 数 | **AI Review 1 回につき dispatch 1 回 → Workflow Run 1 回** |
 
 `client_payload`（必須キー）:
@@ -214,7 +214,12 @@ Human 経路では Review Result のパースは行わないため、本節は A
 
 ### 6.4 dispatch ヘルパー
 
-[`.github/scripts/dispatch-pr-review-status-sync.cjs`](../../../.github/scripts/dispatch-pr-review-status-sync.cjs) が `repository_dispatch` を 1 回 POST する。`/review-pr` §15.5 から利用する。
+| スクリプト | 用途 |
+| ---------- | ---- |
+| [`.github/scripts/publish-ai-review-and-dispatch.cjs`](../../../.github/scripts/publish-ai-review-and-dispatch.cjs) | **推奨**。AI Review コメント投稿 + `repository_dispatch` を 1 コマンドで実行。`--verify` で dispatch 忘れを検査 |
+| [`.github/scripts/dispatch-pr-review-status-sync.cjs`](../../../.github/scripts/dispatch-pr-review-status-sync.cjs) | dispatch のみ（recovery / 低レベル API） |
+
+`/review-pr` §15.5 から **`publish-ai-review-and-dispatch.cjs` を正本** とする。
 
 ## 7. 処理概要
 
@@ -259,8 +264,9 @@ Slack通知に失敗しても、Projects Status の更新は取り消さない�
 ## 10. 運用上の必須事項
 
 - Project の Status に **AI Review** / **Human Review** / **In Progress** が存在し、表示名が [Projects運用ルール.md](../../00_共通/プロジェクト管理/Projects運用ルール.md) §9 と一致すること
-- `/review-pr` は PR コメント投稿後に **必ず** `dispatch-pr-review-status-sync.cjs`（または同等の `repository_dispatch`）を **1 回** 実行すること
+- `/review-pr` は **`publish-ai-review-and-dispatch.cjs`**（コメント + dispatch）を **1 回** 実行すること。完了前に `--verify` で dispatch 済みを確認してもよい
 - PR コメントは [ai-review-comment.md](../../../prompts/templates/review/ai-review-comment.md) 形式で投稿すること（人間・監査用。Status 同期のトリガには使わない）
+- dispatch 忘れ時は `--dispatch-only` または `workflow_dispatch` で再実行する
 - PR 本文に Task Issue への参照（`Related to #<n>` 等）を含めること（§6.4）。不足時はワークフローが失敗する
 - 本ワークフローが **失敗（赤）** した場合は、Summary の PR・失敗理由を確認し、テンプレート・コメント・Issue 参照を修正してから再実行すること
 - `PROJECTS_TOKEN` には対象 Project の読み書きに必要なスコープを付与すること


### PR DESCRIPTION
Related to #265

## Summary

- `publish-ai-review-and-dispatch.cjs` を追加（AI Review コメント + dispatch を 1 コマンド）
- `--verify` で dispatch 忘れを検査、`--dispatch-only` で recovery
- `/review-pr` §15.5 と仕様書を更新

## Test plan

- [x] `node --test .github/scripts/publish-ai-review-and-dispatch.test.cjs` pass
- [ ] develop マージ後: orchestrator で PR コメント + dispatch + `--verify` ok
