### PR TITLE
feat: review-pr Harness dispatch verify and Commands doc

### DIFF
--- a/.cursor/commands/review-pr.md
+++ b/.cursor/commands/review-pr.md
@@ -804,6 +804,44 @@ approve_for_human_review / request_changes / needs_human_decision / split_requir
 ```
 ---
 
+## dry-run 実行時
+
+Definition Run Harness 等で `run_mode=dry-run` の場合、PR への書き込み・Status 更新は行わない。以下を出力する。
+
+1. レビュー結果分類（Review Result）
+2. ai-review-comment.md 形式の **投稿予定コメント全文**（§1 `Review Result` / §22 `次Status` を含む）
+3. 実行予定の `publish-ai-review-and-dispatch.cjs` コマンド例（`--repository` / `--pr` / `--comment-file`）
+4. Status更新意図（現在 Status → 次 Status）
+5. 次に実行する Command（`/fix-review-comments` 等）
+
+dry-run では `gh pr comment` / `repository_dispatch` / Projects 直接更新を行わない。
+
+---
+
+## Definition Run としての外部実行
+
+本 Command は Cursor IDE に加え、Definition Run Harness からも実行できる。正本は [Definition Run Harness ワークフロー仕様書](../../docs/06_実装設計/github_actions/Definition%20Run%20Harness%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC%E4%BB%95%E6%A7%98%E6%9B%B8.md) とする。
+
+### 外部実行時に守る条件
+
+| run_mode | 挙動 |
+| -------- | ---- |
+| `dry-run` | レビュー結果を「dry-run 実行時」フォーマットで出力。PR コメント・dispatch・Status 更新は **禁止** |
+| `live-run` | 本 md 手順に従い、完了時 **必ず** `publish-ai-review-and-dispatch.cjs` を 1 回実行 |
+
+Harness 入力:
+
+| 入力 | 必須 | 説明 |
+| ---- | ---- | ---- |
+| `command` | 必須 | `review-pr` |
+| `definition` | 必須 | `prompts/definitions/` 配下の review Definition |
+| `run_mode` | 必須 | `dry-run` または `live-run` |
+| `target_pr` | live-run 時必須 | 対象 PR 番号 |
+
+live-run 完了後、Harness post-run 検証が dispatch 忘れを検知する。違反時は Guard Violations に `review_dispatch` が列挙され、ジョブは失敗する。
+
+---
+
 ## 出力ルール
 
 - 事実と推論を分けて書く

--- a/.github/scripts/definition-run-post-verify.cjs
+++ b/.github/scripts/definition-run-post-verify.cjs
@@ -154,6 +154,44 @@ function describePullViolation(pull, runActor) {
   };
 }
 
+function describeReviewDispatchViolation({ prNumber, verifyResult }) {
+  return {
+    type: "review_dispatch",
+    number: Number(prNumber),
+    title: verifyResult.reason || verifyResult.message || "dispatch_missing",
+    url: verifyResult.latest_ai_review_comment_url || verifyResult.recovery_command || "",
+    created_at: verifyResult.latest_ai_review_comment_at || "",
+    actor_login: "-",
+    actor_type: "review_dispatch",
+    recovery_command: verifyResult.recovery_command || "",
+  };
+}
+
+async function runReviewPrDispatchVerify({
+  owner,
+  repo,
+  targetPr,
+  token,
+  fetchImpl,
+  verifyImpl,
+}) {
+  if (!targetPr) {
+    return { ok: true, skipped: true, reason: "no_target_pr" };
+  }
+  const publish = require("./publish-ai-review-and-dispatch.cjs");
+  const verify =
+    verifyImpl ||
+    ((options) =>
+      publish.verifyAiReviewDispatch({
+        owner,
+        repo,
+        prNumber: targetPr,
+        token,
+        fetchImpl,
+      }));
+  return verify({ owner, repo, prNumber: targetPr, token, fetchImpl });
+}
+
 function describeBranchViolation(branch, runActor) {
   const login = branch.author_login || branch.committer_login || "";
   const actorType = classifyActor({ login, runActor });
@@ -175,6 +213,11 @@ async function runPostVerify({
   startedAt,
   runMode,
   runActor,
+  command,
+  targetPr,
+  token,
+  fetchImpl,
+  verifyImpl,
   listIssues = listIssuesCreatedSince,
   listPulls = listPullsCreatedSince,
   listBranches = listBranchesCreatedSince,
@@ -210,9 +253,29 @@ async function runPostVerify({
     });
   }
 
+  let dispatchVerify = null;
+  if (String(command || "").trim() === "review-pr" && mode === "live-run" && targetPr) {
+    dispatchVerify = await runReviewPrDispatchVerify({
+      owner,
+      repo,
+      targetPr,
+      token,
+      fetchImpl,
+      verifyImpl,
+    });
+    if (!dispatchVerify.ok && !dispatchVerify.skipped) {
+      violations.push(
+        describeReviewDispatchViolation({ prNumber: targetPr, verifyResult: dispatchVerify }),
+      );
+    }
+  }
+
   return {
     started_at: toIsoZulu(startedAt),
     run_mode: mode,
+    command: String(command || "").trim() || undefined,
+    target_pr: targetPr || undefined,
+    dispatch_verify: dispatchVerify || undefined,
     counts: {
       issues: issues.length,
       pull_requests: pulls.length,
@@ -236,6 +299,11 @@ function formatViolationsMarkdown(result) {
   );
   if (!result.violations.length) {
     lines.push("- result: None");
+    if (result.dispatch_verify && result.dispatch_verify.ok) {
+      lines.push(
+        `- review_dispatch: ok (PR #${result.target_pr || "-"}, run ${result.dispatch_verify.dispatch_run_id || "-"})`,
+      );
+    }
     return `${lines.join("\n")}\n`;
   }
   lines.push("");
@@ -245,7 +313,9 @@ function formatViolationsMarkdown(result) {
     const identifier =
       violation.type === "branch"
         ? `\`${violation.name}\` (${(violation.sha || "").slice(0, 7)})`
-        : `#${violation.number} ${violation.title || ""}`.trim();
+        : violation.type === "review_dispatch"
+          ? `PR #${violation.number} ${violation.title || ""}`.trim()
+          : `#${violation.number} ${violation.title || ""}`.trim();
     const actor = `${violation.actor_login || "-"} (${violation.actor_type})`;
     const url = violation.url || "-";
     lines.push(
@@ -263,12 +333,14 @@ module.exports = {
   describeBranchViolation,
   describeIssueViolation,
   describePullViolation,
+  describeReviewDispatchViolation,
   formatViolationsMarkdown,
   listBranchesCreatedSince,
   listIssuesCreatedSince,
   listPullsCreatedSince,
   parseDate,
   runPostVerify,
+  runReviewPrDispatchVerify,
   shouldFlagInDryRun,
   toIsoZulu,
 };

--- a/.github/scripts/definition-run-post-verify.test.cjs
+++ b/.github/scripts/definition-run-post-verify.test.cjs
@@ -228,3 +228,50 @@ test("listIssuesCreatedSince: octokit 経由で PR 以外の Issue のみ返す"
   assert.equal(called[0].owner, "o");
   assert.equal(called[0].since, "2026-01-01T00:00:00.000Z");
 });
+
+test("runPostVerify: review-pr live-run で dispatch 欠落は violation", async () => {
+  const result = await post.runPostVerify({
+    owner: "o",
+    repo: "r",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    runMode: "live-run",
+    runActor: "agent",
+    command: "review-pr",
+    targetPr: "282",
+    token: "t",
+    listIssues: async () => [],
+    listPulls: async () => [],
+    listBranches: async () => [],
+    verifyImpl: async () => ({
+      ok: false,
+      reason: "dispatch_missing",
+      message: "missing",
+      recovery_command: "node ... --dispatch-only",
+    }),
+  });
+  assert.equal(result.counts.violations, 1);
+  assert.equal(result.violations[0].type, "review_dispatch");
+  assert.equal(result.dispatch_verify.ok, false);
+});
+
+test("runPostVerify: review-pr live-run で dispatch 済みなら violation なし", async () => {
+  const result = await post.runPostVerify({
+    owner: "o",
+    repo: "r",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    runMode: "live-run",
+    runActor: "agent",
+    command: "review-pr",
+    targetPr: "282",
+    token: "t",
+    listIssues: async () => [],
+    listPulls: async () => [],
+    listBranches: async () => [],
+    verifyImpl: async () => ({
+      ok: true,
+      dispatch_run_id: 1,
+    }),
+  });
+  assert.equal(result.counts.violations, 0);
+  assert.equal(result.dispatch_verify.ok, true);
+});

--- a/.github/scripts/definition-run-prompt-builder.cjs
+++ b/.github/scripts/definition-run-prompt-builder.cjs
@@ -15,6 +15,14 @@ const COMMAND_REGISTRY = Object.freeze({
     live_run_supported: false,
     output_section: "dry-run 実行時",
   }),
+  "review-pr": Object.freeze({
+    definition_type: "review",
+    default_ref: "develop",
+    dry_run_supported: true,
+    live_run_supported: true,
+    output_section: "dry-run 実行時",
+    requires_target_pr_on_live_run: true,
+  }),
 });
 
 const SUPPORTED_RUN_MODES = Object.freeze(["dry-run", "live-run"]);
@@ -79,6 +87,20 @@ function sanitizeRequestIssue(value) {
   const numeric = Number(text.replace(/^#/, ""));
   if (!Number.isFinite(numeric) || numeric <= 0 || numeric > DEFAULT_REQUEST_ISSUE_MAX) {
     throw new ValidationError("invalid_request_issue", "request_issue is out of range.");
+  }
+  return String(numeric);
+}
+
+function sanitizeTargetPr(value) {
+  if (value == null) return "";
+  const text = String(value).trim();
+  if (!text) return "";
+  if (!/^\#?\d+$/.test(text)) {
+    throw new ValidationError("invalid_target_pr", "target_pr must be a positive integer or #<num>.");
+  }
+  const numeric = Number(text.replace(/^#/, ""));
+  if (!Number.isFinite(numeric) || numeric <= 0 || numeric > DEFAULT_REQUEST_ISSUE_MAX) {
+    throw new ValidationError("invalid_target_pr", "target_pr is out of range.");
   }
   return String(numeric);
 }
@@ -194,8 +216,8 @@ function validateDefinitionType(absolutePath, expectedType, { fsImpl = fs } = {}
   return actual;
 }
 
-function buildPrompt({ command, definition, run_mode, output_section }) {
-  return [
+function buildPrompt({ command, definition, run_mode, output_section, target_pr }) {
+  const lines = [
     "このリポジトリで Definition Run を実行する。",
     "",
     "遵守:",
@@ -206,6 +228,11 @@ function buildPrompt({ command, definition, run_mode, output_section }) {
     `実行コマンド: /${command}`,
     `対象Definition: @${definition}`,
     `run_mode: ${run_mode}`,
+  ];
+  if (target_pr) {
+    lines.push(`対象PR: #${target_pr}`);
+  }
+  lines.push(
     "",
     "run_mode が dry-run の場合、Issue / Branch / Project / PR / Label / Definition への",
     "あらゆる書き込みを行わない。gh CLI / git push / GitHub API の write 系操作は全面禁止。",
@@ -213,9 +240,27 @@ function buildPrompt({ command, definition, run_mode, output_section }) {
     "`git push` のみで Branch 運用状態を確定しない。",
     "Issue 作成・更新後の同期は既存 workflow が行うため、Harness は同期処理を行わない。",
     "",
+  );
+  if (command === "review-pr" && run_mode === "live-run") {
+    lines.push(
+      "live-run 完了時は .cursor/commands/review-pr.md §15.5 に従い、",
+      "必ず publish-ai-review-and-dispatch.cjs で PR コメント投稿と Status dispatch を 1 回実行する。",
+      "分離実行（コメントのみ / dispatch のみ）は recovery 時のみ。",
+      "Harness post-run 検証で dispatch 忘れがあるとジョブは失敗する。",
+      "",
+    );
+  }
+  if (command === "review-pr" && run_mode === "dry-run") {
+    lines.push(
+      "dry-run では PR コメント投稿・repository_dispatch・Projects Status 更新を行わない。",
+      "",
+    );
+  }
+  lines.push(
     `結果は .cursor/commands/${command}.md の「${output_section}」セクションのフォーマットで出力する。`,
     "",
-  ].join("\n");
+  );
+  return lines.join("\n");
 }
 
 function buildDefinitionRunRequest(rawInput = {}, { workspace, fsImpl } = {}) {
@@ -227,6 +272,10 @@ function buildDefinitionRunRequest(rawInput = {}, { workspace, fsImpl } = {}) {
     : registry.definition_type;
   const requestedBy = sanitizeRequestedBy(rawInput.requested_by);
   const requestIssue = sanitizeRequestIssue(rawInput.request_issue);
+  const targetPr = sanitizeTargetPr(rawInput.target_pr);
+  if (registry.requires_target_pr_on_live_run && runMode === "live-run" && !targetPr) {
+    throw new ValidationError("missing_target_pr", "target_pr is required for review-pr live-run.");
+  }
   const ref = String(rawInput.ref || registry.default_ref || "develop").trim();
 
   const prompt = buildPrompt({
@@ -234,6 +283,7 @@ function buildDefinitionRunRequest(rawInput = {}, { workspace, fsImpl } = {}) {
     definition,
     run_mode: runMode,
     output_section: registry.output_section,
+    target_pr: targetPr,
   });
 
   const maskedPrompt = maskSecrets(prompt);
@@ -246,6 +296,7 @@ function buildDefinitionRunRequest(rawInput = {}, { workspace, fsImpl } = {}) {
     run_mode: runMode,
     requested_by: requestedBy,
     request_issue: requestIssue,
+    target_pr: targetPr,
     ref,
     output_section: registry.output_section,
     prompt: maskedPrompt,
@@ -263,6 +314,7 @@ function summarizeForLog(request) {
     ref: request.ref,
     requested_by: request.requested_by || "-",
     request_issue: request.request_issue || "-",
+    target_pr: request.target_pr || "-",
     output_section: request.output_section,
     allowed_commands: listAllowedCommands(),
   };

--- a/.github/scripts/definition-run-prompt-builder.test.cjs
+++ b/.github/scripts/definition-run-prompt-builder.test.cjs
@@ -53,8 +53,27 @@ function writeEpicDefinition(root, relPath = "prompts/definitions/epics/sample/e
   return relPath;
 }
 
-test("listAllowedCommands: MVPでは start-epic のみ", () => {
-  assert.deepEqual(builder.listAllowedCommands(), ["start-epic"]);
+function writeReviewDefinition(root, relPath = "prompts/definitions/_examples/review-definition.example.yaml", body) {
+  const fullPath = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(
+    fullPath,
+    body ||
+      [
+        'schema_version: "1.0"',
+        'definition_type: "review"',
+        "review:",
+        '  id: "review-sample"',
+        '  title: "sample review"',
+        "",
+      ].join("\n"),
+    "utf8",
+  );
+  return relPath;
+}
+
+test("listAllowedCommands: start-epic と review-pr", () => {
+  assert.deepEqual(builder.listAllowedCommands(), ["start-epic", "review-pr"]);
 });
 
 test("validateCommand: 未登録 Command は unsupported_command", () => {
@@ -324,7 +343,57 @@ test("summarizeForLog: 必要フィールドだけ返す", () => {
     assert.equal(summary.command, "start-epic");
     assert.equal(summary.run_mode, "dry-run");
     assert.equal(summary.definition_type, "epic");
-    assert.deepEqual(summary.allowed_commands, ["start-epic"]);
+    assert.deepEqual(summary.allowed_commands, ["start-epic", "review-pr"]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("review-pr: live-run は target_pr 必須", () => {
+  const root = withTempWorkspace((dir) => writeReviewDefinition(dir));
+  try {
+    assert.throws(
+      () =>
+        builder.buildDefinitionRunRequest(
+          {
+            command: "review-pr",
+            definition: "prompts/definitions/_examples/review-definition.example.yaml",
+            run_mode: "live-run",
+          },
+          { workspace: root },
+        ),
+      (err) => err instanceof builder.ValidationError && err.code === "missing_target_pr",
+    );
+    const request = builder.buildDefinitionRunRequest(
+      {
+        command: "review-pr",
+        definition: "prompts/definitions/_examples/review-definition.example.yaml",
+        run_mode: "live-run",
+        target_pr: "282",
+      },
+      { workspace: root },
+    );
+    assert.equal(request.target_pr, "282");
+    assert.match(request.prompt, /publish-ai-review-and-dispatch/);
+    assert.match(request.prompt, /対象PR: #282/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("review-pr: dry-run は target_pr なしでも受理", () => {
+  const root = withTempWorkspace((dir) => writeReviewDefinition(dir));
+  try {
+    const request = builder.buildDefinitionRunRequest(
+      {
+        command: "review-pr",
+        definition: "prompts/definitions/_examples/review-definition.example.yaml",
+        run_mode: "dry-run",
+      },
+      { workspace: root },
+    );
+    assert.equal(request.run_mode, "dry-run");
+    assert.match(request.prompt, /PR コメント投稿・repository_dispatch・Projects Status 更新を行わない/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/.github/workflows/definition-run.yml
+++ b/.github/workflows/definition-run.yml
@@ -7,16 +7,17 @@ on:
   workflow_dispatch:
     inputs:
       command:
-        description: 実行する Cursor Command（MVP は start-epic のみ）
+        description: 実行する Cursor Command
         required: true
         type: choice
         options:
           - start-epic
+          - review-pr
       definition:
         description: 対象 Definition のリポジトリ相対パス（prompts/definitions/ 配下）
         required: true
       run_mode:
-        description: 実行モード（MVP は dry-run のみ受理）
+        description: 実行モード（start-epic は dry-run のみ。review-pr は live-run 可）
         required: true
         type: choice
         default: dry-run
@@ -31,11 +32,16 @@ on:
         description: 依頼者識別子（任意、監査用）
         required: false
         default: ""
+      target_pr:
+        description: review-pr live-run 時の対象 PR 番号（必須）
+        required: false
+        default: ""
 
 permissions:
   contents: read
   issues: read
   pull-requests: read
+  actions: read
 
 concurrency:
   group: definition-run-${{ github.event.client_payload.definition || inputs.definition }}
@@ -65,11 +71,13 @@ jobs:
           PAYLOAD_RUN_MODE: ${{ github.event.client_payload.run_mode }}
           PAYLOAD_REQUEST_ISSUE: ${{ github.event.client_payload.request_issue }}
           PAYLOAD_REQUESTED_BY: ${{ github.event.client_payload.requested_by }}
+          PAYLOAD_TARGET_PR: ${{ github.event.client_payload.target_pr }}
           INPUT_COMMAND: ${{ inputs.command }}
           INPUT_DEFINITION: ${{ inputs.definition }}
           INPUT_RUN_MODE: ${{ inputs.run_mode }}
           INPUT_REQUEST_ISSUE: ${{ inputs.request_issue }}
           INPUT_REQUESTED_BY: ${{ inputs.requested_by }}
+          INPUT_TARGET_PR: ${{ inputs.target_pr }}
         run: |
           set -euo pipefail
           echo "::group::resolve-inputs"
@@ -78,12 +86,14 @@ jobs:
           RUN_MODE="${PAYLOAD_RUN_MODE:-${INPUT_RUN_MODE:-}}"
           REQUEST_ISSUE="${PAYLOAD_REQUEST_ISSUE:-${INPUT_REQUEST_ISSUE:-}}"
           REQUESTED_BY="${PAYLOAD_REQUESTED_BY:-${INPUT_REQUESTED_BY:-${GITHUB_ACTOR:-}}}"
-          echo "decision: resolve event=${GITHUB_EVENT_NAME} command=${COMMAND} run_mode=${RUN_MODE}"
+          TARGET_PR="${PAYLOAD_TARGET_PR:-${INPUT_TARGET_PR:-}}"
+          echo "decision: resolve event=${GITHUB_EVENT_NAME} command=${COMMAND} run_mode=${RUN_MODE} target_pr=${TARGET_PR:-}"
           echo "command=${COMMAND}" >> "$GITHUB_OUTPUT"
           echo "definition=${DEFINITION}" >> "$GITHUB_OUTPUT"
           echo "run_mode=${RUN_MODE}" >> "$GITHUB_OUTPUT"
           echo "request_issue=${REQUEST_ISSUE}" >> "$GITHUB_OUTPUT"
           echo "requested_by=${REQUESTED_BY}" >> "$GITHUB_OUTPUT"
+          echo "target_pr=${TARGET_PR}" >> "$GITHUB_OUTPUT"
           echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
           echo "::endgroup::"
 
@@ -95,6 +105,7 @@ jobs:
           INPUT_RUN_MODE: ${{ steps.resolve.outputs.run_mode }}
           INPUT_REQUEST_ISSUE: ${{ steps.resolve.outputs.request_issue }}
           INPUT_REQUESTED_BY: ${{ steps.resolve.outputs.requested_by }}
+          INPUT_TARGET_PR: ${{ steps.resolve.outputs.target_pr }}
         run: |
           set -euo pipefail
           echo "::group::validate-and-build-prompt"
@@ -111,6 +122,7 @@ jobs:
             run_mode: process.env.INPUT_RUN_MODE,
             request_issue: process.env.INPUT_REQUEST_ISSUE,
             requested_by: process.env.INPUT_REQUESTED_BY,
+            target_pr: process.env.INPUT_TARGET_PR,
           };
 
           try {
@@ -327,6 +339,8 @@ jobs:
           STARTED_AT: ${{ steps.resolve.outputs.started_at }}
           RUN_MODE: ${{ steps.resolve.outputs.run_mode }}
           RUN_ACTOR: ${{ github.actor }}
+          COMMAND: ${{ steps.resolve.outputs.command }}
+          TARGET_PR: ${{ steps.resolve.outputs.target_pr }}
         uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -345,11 +359,15 @@ jobs:
             const startedAt = process.env.STARTED_AT;
             const runMode = process.env.RUN_MODE || "dry-run";
             const runActor = process.env.RUN_ACTOR || "";
+            const command = process.env.COMMAND || "";
+            const targetPr = process.env.TARGET_PR || "";
             console.log(
               builder.decisionLine("post-verify-start", {
                 started_at: startedAt,
                 run_mode: runMode,
                 run_actor: runActor,
+                command,
+                target_pr: targetPr || "-",
               }),
             );
 
@@ -360,6 +378,9 @@ jobs:
               startedAt,
               runMode,
               runActor,
+              command,
+              targetPr,
+              token: process.env.GITHUB_TOKEN,
             });
             console.log(
               builder.decisionLine("post-verify-done", {

--- a/docs/00_共通/AIエージェント運用/Commands設計書.md
+++ b/docs/00_共通/AIエージェント運用/Commands設計書.md
@@ -725,13 +725,14 @@ PR番号を併記してもよい。
 13. 横断影響を確認する
 14. 前段成果物の修正が必要か確認する
 15. レビューコメントを作成する
-16. AIレビュー結果をPRへ記録する
-17. 指摘なしなら Human Review へ進める
-18. 指摘ありなら In Progress へ戻す判断材料を出す
+16. AIレビュー結果をPRへ記録する（live-run / IDE 実行時）
+17. **`publish-ai-review-and-dispatch.cjs` で Status dispatch を 1 回実行する**（§17.10）
+18. 指摘なしなら Human Review へ進める
+19. 指摘ありなら In Progress へ戻す判断材料を出す
 
 ```
 
-正本手順の詳細は `.cursor/commands/review-pr.md` とする。
+正本手順の詳細は `.cursor/commands/review-pr.md` とする。Status 同期の CLI 正本は §17.10。
 
 前段成果物の修正が必要な場合は、以下の基準で扱う。
 
@@ -767,6 +768,7 @@ PR番号を併記してもよい。
 ### 17.8 成功条件
 
 - PRへAIレビュー結果が記録されている
+- **`publish-ai-review-and-dispatch.cjs` によりコメント投稿と `repository_dispatch` が 1 回完了している**（または `--verify` で dispatch 済みを確認済み）
 - 修正要否が明確である
 - Human Reviewへ進めてよいか判断できる
 - 指摘がある場合、修正対象が明確である
@@ -781,6 +783,20 @@ PR番号を併記してもよい。
 - 識別子付き Task PR で差分 path が親 Epic の `epic_scope.allowed_paths` 外を含む（`blocked`）
 - 識別子 prefix が親 Epic と不一致（`blocked`）
 - `MOD-RECO-NNN` Epic 配下で `apps/reco/src/app/**` に差分がある（`blocked`）
+
+### 17.10 Status 同期（dispatch 忘れ防止）
+
+AI Review 完了後の Projects Status 更新は [PR Review Status Sync](../../06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md) が担う。`/review-pr` は **コメント投稿と dispatch を分離しない**。
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 正本 CLI | `.github/scripts/publish-ai-review-and-dispatch.cjs` |
+| 推奨 | `--comment-file` で ai-review-comment 形式を渡し、コメント + dispatch を 1 回実行 |
+| 完了確認 | 同一 CLI の `--verify` |
+| recovery | `--dispatch-only`（コメント投稿済み時） |
+| Harness | `review-pr` + `live-run` 完了後、post-run 検証で dispatch 忘れを **ジョブ失敗** |
+
+詳細手順は `.cursor/commands/review-pr.md` §15.5 を正本とする。
 
 ---
 

--- a/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
@@ -25,7 +25,7 @@ Definition Run の通称・Command 定義・Task Definition 構造の正本は�
 | workflow | `.github/workflows/definition-run.yml` | `repository_dispatch` / `workflow_dispatch` トリガ、入力検証、Cursor SDK 呼び出し、post-run 検証、Job Summary 出力 |
 | 共通 script | `.github/scripts/definition-run-prompt-builder.cjs` | Command レジストリ、入力検証、プロンプト組み立て、secret マスク |
 | 単体テスト | `.github/scripts/definition-run-prompt-builder.test.cjs` | builder の正常系・異常系・secret マスクの検証 |
-| 共通 script | `.github/scripts/definition-run-post-verify.cjs` | 実行後の Issue / PR / Branch 新規作成検知、違反判定、Job Summary 用 Markdown 生成 |
+| 共通 script | `.github/scripts/definition-run-post-verify.cjs` | 実行後の Issue / PR / Branch 新規作成検知、**review-pr dispatch 忘れ検証**、違反判定、Job Summary 用 Markdown 生成 |
 | 単体テスト | `.github/scripts/definition-run-post-verify.test.cjs` | post-verify の正常系・違反検出系の検証 |
 | Actions 表示名 | `Definition Run Harness` | |
 
@@ -56,10 +56,11 @@ on:
 
 | 項目 | 必須 | 値 | 説明 |
 | ---- | ---- | ---- | ---- |
-| `command` | 必須 | `start-epic`（MVP）／ 将来 `start-task` 等 | Command レジストリに登録された値のみ受理。それ以外は失敗 |
+| `command` | 必須 | `start-epic`（dry-run のみ）／ `review-pr`（dry-run / live-run）／ 将来 `start-task` 等 | Command レジストリに登録された値のみ受理。それ以外は失敗 |
 | `definition` | 必須 | リポジトリ相対パス | `prompts/definitions/` 配下に限定。実ファイル存在を検証 |
-| `run_mode` | 必須 | `dry-run` | MVP は `dry-run` のみ受理。`live-run` は **必ず失敗** |
+| `run_mode` | 必須 | `dry-run` / `live-run` | Command ごとに supported を参照。`start-epic` は `dry-run` のみ。`review-pr` は両方可 |
 | `request_issue` | 任意 | 数値 | トレース相関キー。Job Summary 冒頭に表示するのみ（Issue へのコメント投稿はしない） |
+| `target_pr` | 条件付き必須 | 数値 | **`review-pr` + `live-run` 時は必須**。post-run で dispatch 忘れ検証に使用 |
 | `requested_by` | 任意 | 自由文字列 | 監査用識別子（Slack user / GitHub user 等）。Job Summary に表示。改行・長さ制限あり |
 
 ## 5. 処理フロー
@@ -84,6 +85,7 @@ on:
 | permissions | `pull-requests: read` | post-verify で PR 一覧取得 |
 | Secret | `CURSOR_API_KEY` | Cursor SDK の認証。workflow env のみで使用、プロンプト・log・Summary には絶対に出さない |
 | Token | `GITHUB_TOKEN` | post-verify で gh API を叩く（read のみ。write 全廃） |
+| permissions | `actions: read` | review-pr post-verify で workflow runs 参照 |
 
 write 系権限は MVP 段階で **付与しない**。Cloud Agent が誤って書き込みを試みても物理的に成功しない構造とする。
 
@@ -305,7 +307,7 @@ Definition Run Harness が live-run で Issue を起票した後、以下の既�
 | Issue メタデータ → Project 同期 | `.github/workflows/issue-metadata-project-branch.yml` | Issue 本文に Issue 運用メタデータを正しく埋めて作成のみ |
 | Issue → Branch 作成 | 同上 | Issue 本文 no-branch チェックを正しく設定 |
 | PR 作成時 Status / Slack | `.github/workflows/pr-created-status-and-slack.yml` | PR 作成のみ |
-| PR レビュー → Status | `.github/workflows/pr-review-status-sync.yml` | レビュー操作のみ |
+| PR レビュー → Status | `.github/workflows/pr-review-status-sync.yml` | **`publish-ai-review-and-dispatch.cjs` で dispatch**（Agent 実行）。Harness live-run 後は post-verify で dispatch 忘れを検証 |
 | PR merge → Done / Slack | `.github/workflows/pr-merged-done-and-slack.yml` | merge は人間判断（AI 不可） |
 | 手動 Slack 通知 | `.github/workflows/slack-notify-manual.yml` | 必要時に `workflow_dispatch` |
 


### PR DESCRIPTION
Related to #265

## Summary

- Commands設計書 §17.10 に Status 同期（`publish-ai-review-and-dispatch.cjs`）手順を追記
- Definition Run Harness に `review-pr` を登録（dry-run / live-run）
- live-run 後 post-verify で dispatch 忘れを `review_dispatch` violation として検知
- `target_pr` 入力を workflow に追加

## Test plan

- [x] `node --test` definition-run + publish scripts（41 pass）
- [ ] merge 後: PR #282 で `--verify` が ok であること
