### PR TITLE
feat: machine account運用をMVP Cycle 3標準フローに組み込む

### DIFF
--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -319,6 +319,15 @@ Closes #<Epic Issue番号>
 
 確認が完了した場合、PRを作成する。
 
+**Machine account 認証（必須）:** PR open 前に bot 認証を確認する（[github-operation.mdc](../../.cursor/rules/github-operation.mdc) §3.16、[AI機械アカウント運用設計書](../../docs/00_共通/AIエージェント運用/AI機械アカウント運用設計書.md)）。
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
+PR 作成後、`gh pr view <番号> --json author --jq .author.login` が `.github/ai-bot-account.json` の `machine_account_login` であることを確認する。
+
 PR作成時に確認すること。
 
 - PR titleが適切か

--- a/.cursor/commands/fix-review-comments.md
+++ b/.cursor/commands/fix-review-comments.md
@@ -101,6 +101,15 @@ Definitionなしでの実行は原則禁止する。
 
 ## 処理手順
 
+### 0. Machine account 認証（GitHub 書き込み前・必須）
+
+push / commit の前に bot 認証を確認する（[github-operation.mdc](../../.cursor/rules/github-operation.mdc) §3.16）。
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
 ### 1. PRレビューコメントを確認する
 
 対象PRのレビューコメントを確認する。

--- a/.cursor/commands/review-pr.md
+++ b/.cursor/commands/review-pr.md
@@ -105,6 +105,15 @@ PRレビュー時は、特に以下を重視する。
 
 ## 処理手順
 
+### 0. Machine account 認証（GitHub 書き込み前・必須）
+
+commit / push / PR コメント / dispatch の前に bot 認証を確認する（[github-operation.mdc](../../.cursor/rules/github-operation.mdc) §3.16）。
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
 ### 1. PRを確認する
 
 対象PRを確認する。

--- a/.cursor/commands/start-task.md
+++ b/.cursor/commands/start-task.md
@@ -95,6 +95,15 @@ Definitionなしでの実行は原則禁止する。
 
 ## 処理手順
 
+### 0. Machine account 認証（GitHub 書き込み前・必須）
+
+Issue 作成 / Branch push / commit の前に bot 認証を確認する（[github-operation.mdc](../../.cursor/rules/github-operation.mdc) §3.16）。
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
 ### 1. Task Definitionを読み込む
 
 指定されたDefinitionを読み込む。

--- a/.cursor/commands/work-issue.md
+++ b/.cursor/commands/work-issue.md
@@ -85,6 +85,15 @@ Definitionなしでの実行は原則禁止する。
 
 ## 処理手順
 
+### 0. Machine account 認証（GitHub 書き込み前・必須）
+
+push / commit の前に bot 認証を確認する（[github-operation.mdc](../../.cursor/rules/github-operation.mdc) §3.16）。
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
 ### 1. Issueを確認する
 
 対象Issueを確認し、以下を整理する。

--- a/.cursor/rules/github-operation.mdc
+++ b/.cursor/rules/github-operation.mdc
@@ -384,6 +384,31 @@ AI Agentがcommitを作成する場合は、必ず `git-commit-message.mdc` を�
 - 自動生成結果が英語の場合は、人間またはAI Agentが日本語へ修正する
 - 最終的な強制は `.githooks/commit-msg` で行う
 
+### 3.16 Machine Account 認証（Human Review 前提）
+
+AI Agent が GitHub へ **書き込む** 操作（commit / push / Issue 作成 / PR 作成 / AI Review dispatch）を行う前に、**machine account**（`.github/ai-bot-account.json` の `machine_account_login`、現行: `okuri-ai-bot`）として認証すること。
+
+| 操作 | 認証 |
+| ---- | ---- |
+| commit / push / `gh issue create` / `gh pr create` | machine account PAT（`GH_BOT_TOKEN`） |
+| Human Review（Approve / Request changes）/ merge | 人間アカウント（`ryo-chan-k6`）。bot 認証を使わない |
+
+**作業開始前（必須）:**
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
+- PAT は **machine account で発行した Classic PAT**（`repo`）。人間アカウントの PAT では PR author が人間になり、Human Review 正式経路が使えない。
+- PAT は `~/.config/gift-recommend/gh-bot.env` に保管（`.github/gh-bot.env.example` 参照）。リポジトリに commit しない。
+- 詳細は [AI機械アカウント運用設計書](../../docs/00_共通/AIエージェント運用/AI機械アカウント運用設計書.md) を正とする。
+
+**禁止:**
+
+- 人間 PAT のまま `gh pr create` すること
+- machine account で Approve / Request changes / merge すること
+
 ---
 
 ## 4. 確認観点
@@ -478,6 +503,8 @@ AI Agentは、以下を行ってはならない。
 - 識別子付き Task で、Parent Epic と識別子 prefix が一致しない状態のまま Task を進めること
 - generatedファイル、OpenAPI、DB、CI/CDなど横断影響がある変更を通常Taskに無断で混在させること
 - secretや認証情報をIssue、PR、commit、Slack通知、ai-logsへ記載すること
+- 人間 PAT のまま PR を open すること（Human Review 不可になる）
+- machine account PAT（`GH_BOT_TOKEN`）をリポジトリへ commit すること
 - コミットメッセージ詳細ルールをこのRuleへ過剰に重複定義すること
 - worktree安全確認の詳細をこのRuleへ重複定義すること
 
@@ -549,6 +576,7 @@ AI Agentは、以下の場合、人間へ確認・報告する。
 | Task Definition設計書                      | 個別作業条件の構造                           |
 | Prompts運用ルール                          | `prompts/` 配下の配置・命名                  |
 | AIレビュー運用設計書                       | AI Reviewの品質観点                          |
+| AI機械アカウント運用設計書                 | machine account / PAT / Human Review 分離   |
 | AIログ運用ルール                           | `ai-logs/` の利用範囲                        |
 | Slack通知運用設計書                        | Slack通知タイミング・文面                    |
 | worktree運用ルール                         | 並列作業時の作業領域分離                     |

--- a/.github/ai-bot-account.json
+++ b/.github/ai-bot-account.json
@@ -1,0 +1,7 @@
+{
+  "machine_account_login": "okuri-ai-bot",
+  "human_reviewer_login": "ryo-chan-k6",
+  "token_env_var": "GH_BOT_TOKEN",
+  "env_file": "~/.config/gift-recommend/gh-bot.env",
+  "repository": "ryo-chan-k6/GiftRecommendAPP_MVP_CYCLE_3"
+}

--- a/.github/gh-bot.env.example
+++ b/.github/gh-bot.env.example
@@ -1,0 +1,4 @@
+# Copy to ~/.config/gift-recommend/gh-bot.env (chmod 600).
+# Machine account: see .github/ai-bot-account.json
+# Do not commit gh-bot.env or PAT values.
+export GH_BOT_TOKEN=ghp_your_token_here

--- a/.github/scripts/e2e-bot-author-test-pr.sh
+++ b/.github/scripts/e2e-bot-author-test-pr.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(diname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+CONFIG_JSON="$(node -e "const c=require('./.github/ai-bot-account.json'); console.log([c.machine_account_login,c.repository||'ryo-chan-k6/GiftRecommendAPP_MVP_CYCLE_3'].join('|'))")"
+BOT_USER="${CONFIG_JSON%%|*}"
+REPO="${CONFIG_JSON#*|}"
+BRANCH="test/bot-author-human-review-e2e"
+BASE="develop"
+
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+GIT_USER_JSON="$(node .github/scripts/gh-bot-auth.cjs print-git-user)"
+GIT_NAME="$(node -e "console.log(JSON.parse(process.argv[1]).name)" "$GIT_USER_JSON")"
+GIT_EMAIL="$(node -e "console.log(JSON.parse(process.argv[1]).email)" "$GIT_USER_JSON")"
+
+TOKEN="${GH_BOT_TOKEN:?GH_BOT_TOKEN is required}"
+
+git fetch origin "$BASE"
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git checkout "$BRANCH"
+else
+  git checkout -B "$BRANCH" "origin/$BASE"
+fi
+
+git add ai-logs/experiments/2026-05-30-bot-author-human-review-e2e.md
+if git diff --cached --quiet; then
+  echo "No staged changes (file may already be committed)."
+else
+  git -c "user.name=$GIT_NAME" -c "user.email=$GIT_EMAIL" commit -m "$(cat <<EOF
+test: bot author Human Review E2E用マーカー
+
+${BOT_USER} が PR author になることを確認する。
+EOF
+)"
+fi
+
+git push "https://x-access-token:${TOKEN}@github.com/${REPO}.git" "HEAD:${BRANCH}"
+
+PR_URL="$(gh pr create \
+  --repo "$REPO" \
+  --base "$BASE" \
+  --head "$BRANCH" \
+  --title "test: bot author Human Review E2E" \
+  --body "$(cat <<EOF
+## 概要
+
+\`${BOT_USER}\` が PR author となり、\`ryo-chan-k6\` が Human Review（Approve / Request changes）できることを確認する E2E 用 PR。
+
+## 確認手順
+
+1. PR author が \`${BOT_USER}\` であること
+2. \`ryo-chan-k6\` で Review changes → Approve / Request changes が選択できること
+
+## 後片付け
+
+検証後 Close 可（merge 不要）。
+EOF
+)")"
+
+PR_NUM="$(gh pr view "$PR_URL" --json number --jq .number)"
+AUTHOR="$(gh pr view "$PR_NUM" --repo "$REPO" --json author --jq .author.login)"
+
+echo ""
+echo "PR: $PR_URL"
+echo "PR number: #$PR_NUM"
+echo "Author: $AUTHOR"
+
+if [[ "$AUTHOR" != "$BOT_USER" ]]; then
+  echo "ERROR: PR author is not $BOT_USER" >&2
+  exit 1
+fi
+
+echo "SUCCESS: PR author is $BOT_USER. Human Review test on GitHub Web as ryo-chan-k6."

--- a/.github/scripts/gh-bot-auth.cjs
+++ b/.github/scripts/gh-bot-auth.cjs
@@ -1,0 +1,219 @@
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const DEFAULT_CONFIG_PATH = path.join(__dirname, "..", "ai-bot-account.json");
+
+function nonEmpty(value) {
+  return String(value || "").trim();
+}
+
+function expandHome(filePath) {
+  const text = nonEmpty(filePath);
+  if (!text.startsWith("~")) return text;
+  return path.join(os.homedir(), text.slice(1).replace(/^[/\\]/, ""));
+}
+
+function loadBotAccountConfig(configPath = DEFAULT_CONFIG_PATH) {
+  const resolved = path.resolve(configPath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`Bot account config not found: ${resolved}`);
+  }
+  const config = JSON.parse(fs.readFileSync(resolved, "utf8"));
+  const login = nonEmpty(config.machine_account_login);
+  if (!login) {
+    throw new Error("machine_account_login is required in ai-bot-account.json");
+  }
+  return {
+    machineAccountLogin: login,
+    humanReviewerLogin: nonEmpty(config.human_reviewer_login),
+    tokenEnvVar: nonEmpty(config.token_env_var) || "GH_BOT_TOKEN",
+    envFile: expandHome(config.env_file || "~/.config/gift-recommend/gh-bot.env"),
+    repository: nonEmpty(config.repository),
+    configPath: resolved,
+  };
+}
+
+function parseEnvFile(content, tokenEnvVar) {
+  const vars = {};
+  for (const rawLine of String(content || "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const exportMatch = /^export\s+([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+    const plainMatch = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+    const match = exportMatch || plainMatch;
+    if (!match) continue;
+    const key = match[1];
+    let value = match[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    vars[key] = value;
+  }
+  return vars[tokenEnvVar] || "";
+}
+
+function loadTokenFromEnvFile(envFile, tokenEnvVar) {
+  if (!envFile || !fs.existsSync(envFile)) return "";
+  return parseEnvFile(fs.readFileSync(envFile, "utf8"), tokenEnvVar);
+}
+
+function resolveBotToken({ config, tokenOverride } = {}) {
+  const cfg = config || loadBotAccountConfig();
+  const fromOverride = nonEmpty(tokenOverride);
+  if (fromOverride) return fromOverride;
+  const fromProcess = nonEmpty(process.env[cfg.tokenEnvVar]);
+  if (fromProcess) return fromProcess;
+  return loadTokenFromEnvFile(cfg.envFile, cfg.tokenEnvVar);
+}
+
+function authHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function fetchGitHubLogin({ token, fetchImpl }) {
+  const send = fetchImpl || global.fetch;
+  if (typeof send !== "function") {
+    throw new Error("fetch is unavailable");
+  }
+  const response = await send("https://api.github.com/user", {
+    headers: authHeaders(token),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`GitHub API /user failed: HTTP ${response.status} ${text}`.trim());
+  }
+  const data = await response.json();
+  return {
+    login: nonEmpty(data.login),
+    id: data.id,
+  };
+}
+
+async function verifyBotAuth({
+  config,
+  token,
+  fetchImpl,
+} = {}) {
+  const cfg = config || loadBotAccountConfig();
+  const resolvedToken = resolveBotToken({ config: cfg, tokenOverride: token });
+  if (!resolvedToken) {
+    return {
+      ok: false,
+      reason: "token_missing",
+      message: `${cfg.tokenEnvVar} is not set. Create ${cfg.envFile} (see .github/gh-bot.env.example).`,
+      config: cfg,
+    };
+  }
+
+  let loginInfo;
+  try {
+    loginInfo = await fetchGitHubLogin({ token: resolvedToken, fetchImpl });
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "api_error",
+      message: error.message,
+      config: cfg,
+    };
+  }
+
+  if (loginInfo.login !== cfg.machineAccountLogin) {
+    return {
+      ok: false,
+      reason: "wrong_login",
+      message: `Expected machine account ${cfg.machineAccountLogin} but authenticated as ${loginInfo.login}. Use the bot Classic PAT, not the human account token.`,
+      login: loginInfo.login,
+      config: cfg,
+    };
+  }
+
+  return {
+    ok: true,
+    login: loginInfo.login,
+    id: loginInfo.id,
+    token: resolvedToken,
+    gitUser: {
+      name: loginInfo.login,
+      email: `${loginInfo.id}+${loginInfo.login}@users.noreply.github.com`,
+    },
+    config: cfg,
+  };
+}
+
+function formatShellSetup(result) {
+  const cfg = result.config;
+  return [
+    `# Machine account auth (${cfg.machineAccountLogin})`,
+    `source ${cfg.envFile} 2>/dev/null || true`,
+    `export GH_TOKEN="$${cfg.tokenEnvVar}"`,
+    `export GITHUB_TOKEN="$${cfg.tokenEnvVar}"`,
+    `# verify: gh api user --jq .login  # => ${cfg.machineAccountLogin}`,
+  ].join("\n");
+}
+
+async function main(argv) {
+  const args = argv.slice(2);
+  const command = args[0] || "verify";
+
+  if (command === "verify") {
+    const result = await verifyBotAuth();
+    if (!result.ok) {
+      console.error(result.message);
+      process.exit(1);
+    }
+    console.log(`OK: authenticated as ${result.login}`);
+    if (result.config.humanReviewerLogin) {
+      console.log(`Human Reviewer: ${result.config.humanReviewerLogin}`);
+    }
+    return;
+  }
+
+  if (command === "print-setup") {
+    const result = await verifyBotAuth();
+    if (!result.ok) {
+      console.error(result.message);
+      process.exit(1);
+    }
+    console.log(formatShellSetup(result));
+    return;
+  }
+
+  if (command === "print-git-user") {
+    const result = await verifyBotAuth();
+    if (!result.ok) {
+      console.error(result.message);
+      process.exit(1);
+    }
+    console.log(JSON.stringify(result.gitUser));
+    return;
+  }
+
+  console.error(`Unknown command: ${command}. Use verify | print-setup | print-git-user`);
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main(process.argv).catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  DEFAULT_CONFIG_PATH,
+  loadBotAccountConfig,
+  resolveBotToken,
+  verifyBotAuth,
+  formatShellSetup,
+  expandHome,
+};

--- a/.github/scripts/gh-bot-auth.test.cjs
+++ b/.github/scripts/gh-bot-auth.test.cjs
@@ -1,0 +1,84 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { test } = require("node:test");
+
+const ghBotAuth = require("./gh-bot-auth.cjs");
+
+test("expandHome expands tilde path", () => {
+  assert.match(ghBotAuth.expandHome("~/foo/bar"), new RegExp(`${os.homedir()}[/\\\\]foo[/\\\\]bar$`));
+});
+
+test("loadBotAccountConfig reads machine account login", () => {
+  const config = ghBotAuth.loadBotAccountConfig();
+  assert.equal(config.machineAccountLogin, "okuri-ai-bot");
+  assert.equal(config.humanReviewerLogin, "ryo-chan-k6");
+});
+
+test("resolveBotToken prefers explicit override", () => {
+  const config = ghBotAuth.loadBotAccountConfig();
+  assert.equal(ghBotAuth.resolveBotToken({ config, tokenOverride: "ghp_test" }), "ghp_test");
+});
+
+test("verifyBotAuth fails when token missing", async () => {
+  const config = ghBotAuth.loadBotAccountConfig();
+  const result = await ghBotAuth.verifyBotAuth({
+    config: { ...config, envFile: "/tmp/nonexistent-gh-bot.env", tokenEnvVar: "GH_BOT_TOKEN" },
+    token: "",
+    fetchImpl: async () => ({ ok: true, json: async () => ({ login: "okuri-ai-bot", id: 1 }) }),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "token_missing");
+});
+
+test("verifyBotAuth fails on wrong login", async () => {
+  const config = ghBotAuth.loadBotAccountConfig();
+  const result = await ghBotAuth.verifyBotAuth({
+    config,
+    token: "ghp_test",
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({ login: "ryo-chan-k6", id: 2 }),
+    }),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "wrong_login");
+});
+
+test("verifyBotAuth succeeds for configured machine account", async () => {
+  const config = ghBotAuth.loadBotAccountConfig();
+  const result = await ghBotAuth.verifyBotAuth({
+    config,
+    token: "ghp_test",
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({ login: "okuri-ai-bot", id: 99 }),
+    }),
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.login, "okuri-ai-bot");
+  assert.equal(result.gitUser.email, "99+okuri-ai-bot@users.noreply.github.com");
+});
+
+test("resolveBotToken reads env file", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gh-bot-env-"));
+  const envFile = path.join(dir, "gh-bot.env");
+  fs.writeFileSync(envFile, 'export GH_BOT_TOKEN="ghp_from_file"\n', "utf8");
+  const config = {
+    ...ghBotAuth.loadBotAccountConfig(),
+    envFile,
+    tokenEnvVar: "GH_BOT_TOKEN",
+  };
+  const previous = process.env.GH_BOT_TOKEN;
+  delete process.env.GH_BOT_TOKEN;
+  try {
+    assert.equal(ghBotAuth.resolveBotToken({ config }), "ghp_from_file");
+  } finally {
+    if (previous === undefined) delete process.env.GH_BOT_TOKEN;
+    else process.env.GH_BOT_TOKEN = previous;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,8 @@ Human Review
 
 どちらの運用でも、Human Reviewと人間によるmerge判断を省略してはならない。
 
+**Machine account:** AI Agent の commit / push / PR 作成は `okuri-ai-bot`（Classic PAT）で行い、Human Review / merge は `ryo-chan-k6` が行う。詳細は [AI機械アカウント運用設計書](docs/00_共通/AIエージェント運用/AI機械アカウント運用設計書.md) および `.github/ai-bot-account.json`。
+
 ---
 
 ## 12. GitHub運用方針
@@ -1125,6 +1127,7 @@ PR作成前に、以下を確認する。
 [ ] PR本文に影響範囲が記載されている
 [ ] PR本文にHuman Review観点が記載されている
 [ ] AI Reviewを実行できる状態である
+[ ] PR author が machine account（`.github/ai-bot-account.json`）である
 ```
 
 ---

--- a/ai-logs/experiments/2026-05-30-bot-author-human-review-e2e.md
+++ b/ai-logs/experiments/2026-05-30-bot-author-human-review-e2e.md
@@ -1,0 +1,28 @@
+# bot author Human Review E2E
+
+## 目的
+
+`okuri-ai-bot`（machine account）の Classic PAT で PR を open し、`ryo-chan-k6` が Human Review（Approve / Request changes）できることを確認する。
+
+正本設定: `.github/ai-bot-account.json`
+
+## 手順
+
+1. bot PAT（`GH_BOT_TOKEN`）で branch push
+2. `gh pr create`（author = `okuri-ai-bot`）
+3. `ryo-chan-k6` で PR を開き Review changes → Approve / Request changes が選べること
+
+## 再実行
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+bash .github/scripts/e2e-bot-author-test-pr.sh
+```
+
+## 後片付け
+
+検証後、この PR は Close してよい（merge 不要）。
+
+## 関連
+
+- [AI機械アカウント運用設計書](../../docs/00_共通/AIエージェント運用/AI機械アカウント運用設計書.md)

--- a/docs/00_共通/AIエージェント運用/AIエージェント活用型_開発運用フロー設計書.md
+++ b/docs/00_共通/AIエージェント運用/AIエージェント活用型_開発運用フロー設計書.md
@@ -607,6 +607,10 @@ AIレビュー完了時の Projects Status 更新は [PRレビュー完了時Sta
 
 人間レビューは、最終品質判断として実施する。
 
+**実施者:** `ryo-chan-k6`（Personal account）。PR author（machine account `okuri-ai-bot`）とは別アカウントとする（[AI機械アカウント運用設計書](./AI機械アカウント運用設計書.md)）。
+
+**GitHub 操作:** Human Review 指摘は PR Review の **Request changes** で行う（Conversation コメントのみでは Status 連動しない）。
+
 人間レビューでは、主に以下を確認する。
 
 - 方針として妥当か

--- a/docs/00_共通/AIエージェント運用/AI機械アカウント運用設計書.md
+++ b/docs/00_共通/AIエージェント運用/AI機械アカウント運用設計書.md
@@ -1,0 +1,98 @@
+# AI機械アカウント（Machine Account）運用設計書
+
+## 1. 目的
+
+MVP Cycle 3 の AI 主導開発において、**Human Review**（GitHub PR Review の Approve / Request changes）を人間（`ryo-chan-k6`）が実施できるよう、GitHub 上の **PR author** と **Human Reviewer** を分離する。
+
+GitHub は PR author 自身に Approve / Request changes を許可しない。AI Agent が人間アカウントの `gh` 認証で PR を open すると author が人間になり、Human Review 正式経路（`changes_requested` → Projects `In Progress`）が使えない。
+
+本書は machine account（`okuri-ai-bot`）と Classic PAT による運用を定義する。
+
+---
+
+## 2. 正本・設定ファイル
+
+| 項目 | 正本 |
+| ---- | ---- |
+| アカウント定義 | `.github/ai-bot-account.json` |
+| 認証検証 CLI | `.github/scripts/gh-bot-auth.cjs` |
+| PAT 設定例 | `.github/gh-bot.env.example` |
+| Cursor Rule | `.cursor/rules/github-operation.mdc` §3.16 |
+| Human Review 経路 | [PRレビュー完了時Status更新ワークフロー仕様書](../../06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md) §5.2 |
+
+---
+
+## 3. アカウント役割
+
+| アカウント | 種別 | 役割 |
+| ---------- | ---- | ---- |
+| `okuri-ai-bot` | Machine account | commit / push / Issue 作成 / PR open / AI Review dispatch |
+| `ryo-chan-k6` | Personal account | Human Review（Approve / Request changes）、merge、リポジトリ管理 |
+
+Organization 移行は MVP Cycle 3 では行わない。bot は **Collaborator（Write）** として個人リポジトリに参加する。
+
+---
+
+## 4. PAT
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 発行主体 | **machine account**（`okuri-ai-bot`）。人間アカウントの PAT ではない |
+| 種別 | **Classic PAT**（`repo` scope）。Collaborator の private repo では Fine-grained PAT で対象 repo を選べない |
+| 保管 | `~/.config/gift-recommend/gh-bot.env`（`chmod 600`）。リポジトリに commit しない |
+| 環境変数 | `GH_BOT_TOKEN` |
+
+---
+
+## 5. AI Agent 作業前の必須手順
+
+GitHub へ **書き込む** 操作（commit / push / `gh issue create` / `gh pr create` / `publish-ai-review-and-dispatch.cjs`）の前:
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
+`verify` が `OK: authenticated as okuri-ai-bot` を返すこと。
+
+commit author は bot 名義に揃える（`print-git-user` の JSON を `git -c user.name=... -c user.email=...` に利用）。
+
+---
+
+## 6. Human Review
+
+| 操作 | 実施者 | 備考 |
+| ---- | ------ | ---- |
+| PR Review → Approve | `ryo-chan-k6` | bot 認証を **解除**（`unset GH_TOKEN` または人間用 gh セッション） |
+| PR Review → Request changes | `ryo-chan-k6` | コメントのみでは Status 連動しない。正式 PR Review 必須 |
+| merge | `ryo-chan-k6` | AI Agent は merge しない |
+
+---
+
+## 7. 禁止事項
+
+- 人間 PAT で AI 作業用 PR を open すること（author が人間になり Human Review 不可）
+- `GH_BOT_TOKEN` を Issue / PR / docs / リポジトリに記載すること
+- machine account で Human Review（Approve / Request changes）すること
+- machine account で merge すること
+
+---
+
+## 8. E2E 検証
+
+検証手順の記録: [ai-logs/experiments/2026-05-30-bot-author-human-review-e2e.md](../../../ai-logs/experiments/2026-05-30-bot-author-human-review-e2e.md)
+
+再実行スクリプト:
+
+```bash
+bash .github/scripts/e2e-bot-author-test-pr.sh
+```
+
+---
+
+## 9. 関連ドキュメント
+
+- [AIエージェント活用型 開発運用フロー設計書](./AIエージェント活用型_開発運用フロー設計書.md) §22
+- [AIレビュー運用設計書](./AIレビュー運用設計書.md)
+- [Commands設計書](./Commands設計書.md) §17 / §18
+- [Projects運用ルール](../プロジェクト管理/Projects運用ルール.md) §17.6

--- a/docs/00_共通/AIエージェント運用/Commands設計書.md
+++ b/docs/00_共通/AIエージェント運用/Commands設計書.md
@@ -595,6 +595,7 @@ PRはレビュー正本であり、作業結果、確認結果、AIレビュー�
 ### 16.5 処理
 
 ````
+0. machine account 認証を確認する（`gh-bot-auth.cjs verify` + `print-setup`）。PR author が bot であること
 1. 対象Issueを確認する
 2. 作業Branchを確認する
 3. Task Branchが親Epic Branchの最新状態を取り込んでいるか確認する
@@ -707,6 +708,7 @@ PR番号を併記してもよい。
 ### 17.5 処理
 
 ```text
+0. machine account 認証を確認する（`gh-bot-auth.cjs`）
 1. PRを確認する
 2. 対象Issueを確認する
 3. Task Definitionを確認する
@@ -795,6 +797,7 @@ AI Review 完了後の Projects Status 更新は [PR Review Status Sync](../../0
 | 完了確認 | 同一 CLI の `--verify` |
 | recovery | `--dispatch-only`（コメント投稿済み時） |
 | Harness | `review-pr` + `live-run` 完了後、post-run 検証で dispatch 忘れを **ジョブ失敗** |
+| Machine account | dispatch / PR コメント投稿前に `GH_BOT_TOKEN` で bot 認証（[AI機械アカウント運用設計書](./AI機械アカウント運用設計書.md)） |
 
 詳細手順は `.cursor/commands/review-pr.md` §15.5 を正本とする。
 

--- a/docs/00_共通/AIエージェント運用/README.md
+++ b/docs/00_共通/AIエージェント運用/README.md
@@ -76,6 +76,7 @@ Slackは通知・サマリ用途であり、作業計画や成果物の正本に
 | `Task Definition設計書.md`                     | AIへの個別作業依頼条件の構造を定義する                      |
 | `Prompts運用ルール.md`                         | `prompts/` 配下の管理・命名・利用ルールを定義する           |
 | `AIレビュー運用設計書.md`                      | AI Reviewの観点、出力、PR反映方針を定義する                 |
+| `AI機械アカウント運用設計書.md`                | machine account / PAT / Human Review 分離を定義する         |
 | `AIログ運用ルール.md`                          | `ai-logs/` の記録対象、粒度、命名規則を定義する             |
 | `Slack通知運用設計書.md`                       | Slack通知タイミング、通知内容、通知先を定義する             |
 | `worktree運用ルール.md`                        | AI並列作業時のworktree配置・削除・競合回避を定義する        |

--- a/docs/00_共通/ディレクトリ構成/プロジェクトディレクトリ構成定義書.md
+++ b/docs/00_共通/ディレクトリ構成/プロジェクトディレクトリ構成定義書.md
@@ -1019,6 +1019,8 @@ ai-logs/cross-cutting/
 
 ```text
 .github/
+├─ ai-bot-account.json
+├─ gh-bot.env.example
 ├─ ISSUE_TEMPLATE/
 ├─ PULL_REQUEST_TEMPLATE.md
 ├─ PULL_REQUEST_TEMPLATE/
@@ -1028,6 +1030,8 @@ ai-logs/cross-cutting/
 
 | パス                       | 役割                                                       |
 | -------------------------- | ---------------------------------------------------------- |
+| `ai-bot-account.json`      | machine account login / human reviewer の正本設定          |
+| `gh-bot.env.example`       | ローカル PAT 設定ファイル（`~/.config/gift-recommend/`）の例 |
 | `ISSUE_TEMPLATE/`          | GitHub UIで利用するIssueテンプレートを配置する             |
 | `PULL_REQUEST_TEMPLATE.md` | GitHub PRテンプレート選択ガイドを配置する                  |
 | `PULL_REQUEST_TEMPLATE/`   | GitHub UIで利用する種別別PRテンプレートを配置する          |
@@ -1106,6 +1110,8 @@ workflow分類はファイル名prefixで表現する。
 | `projects/`      | GitHub Projects連携に関する補助スクリプトを配置する                  |
 | `notifications/` | Slack通知等の通知文面生成・送信補助スクリプトを配置する              |
 | `utils/`         | GitHub運用スクリプト共通utilityを配置する                            |
+
+machine account 認証 CLI（`gh-bot-auth.cjs`）および E2E 用 `e2e-bot-author-test-pr.sh` も `.github/scripts/` 直下に配置する（[AI機械アカウント運用設計書](../AIエージェント運用/AI機械アカウント運用設計書.md)）。
 
 ---
 

--- a/docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md
@@ -271,6 +271,7 @@ Slack通知に失敗しても、Projects Status の更新は取り消さない�
 - 本ワークフローが **失敗（赤）** した場合は、Summary の PR・失敗理由を確認し、テンプレート・コメント・Issue 参照を修正してから再実行すること
 - `PROJECTS_TOKEN` には対象 Project の読み書きに必要なスコープを付与すること
 - Human Review 指摘は GitHub 上の **Request changes**（`changes_requested`）で行うこと（コメントのみでは本経路は動作しない）
+- AI Agent の PR は **machine account**（`.github/ai-bot-account.json`）が author であること。author が人間の場合、Human Review 正式操作（Approve / Request changes）ができない
 
 ## 11. 関連ドキュメント
 


### PR DESCRIPTION
## Summary

- machine account（`okuri-ai-bot`）認証 CLI `gh-bot-auth.cjs` と正本設定 `.github/ai-bot-account.json` を追加
- Commands / Rules / 設計書に bot PAT 必須手順を追記（Human Review 分離）
- E2E 記録と再実行スクリプトを整備

## Test plan

- [x] `node --test .github/scripts/gh-bot-auth.test.cjs`（7 pass）
- [ ] merge 後: AI 作業前に `node .github/scripts/gh-bot-auth.cjs verify` が ok
