### PR TITLE
feat: fix完了時のIn Progress→AI Review Status同期

### DIFF
--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -319,6 +319,15 @@ Closes #<Epic Issue番号>
 
 確認が完了した場合、PRを作成する。
 
+**Machine account 認証（必須）:** PR open 前に bot 認証を確認する（[github-operation.mdc](../../.cursor/rules/github-operation.mdc) §3.16、[AI機械アカウント運用設計書](../../docs/00_共通/AIエージェント運用/AI機械アカウント運用設計書.md)）。
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
+PR 作成後、`gh pr view <番号> --json author --jq .author.login` が `.github/ai-bot-account.json` の `machine_account_login` であることを確認する。
+
 PR作成時に確認すること。
 
 - PR titleが適切か

--- a/.cursor/commands/fix-review-comments.md
+++ b/.cursor/commands/fix-review-comments.md
@@ -291,7 +291,7 @@ commit作成前に以下を確認する。
 
 ### 10. PR本文またはPRコメントを更新する
 
-修正内容に応じて、PR本文またはPRコメントを更新する。
+修正内容に応じて、PR コメントを更新する。再 AI Review 可能な場合は [fix-complete-comment.md](../../prompts/templates/review/fix-complete-comment.md) 形式で投稿する（§12.5 の dispatch 正本）。
 
 記載内容は以下。
 
@@ -350,20 +350,74 @@ PR本文の作業結果・テスト結果が古くなっている場合は、必
 ```
 ---
 
-### 12. Statusを AI Review へ戻す判断材料を出す
+### 12. Statusを AI Review へ戻す
 
-修正対応が完了し、再レビュー可能な状態であれば、Project Statusを `AI Review` へ戻す意図を出力する。
+Fix Outcome に応じて Status 更新を行う。
 
-`/fix-review-comments` の主なStatus影響は以下。
+| 状況                   | Fix Outcome            | Status更新                         |
+| ---------------------- | ---------------------- | ---------------------------------- |
+| 指摘対応完了           | `ready_for_ai_review`  | `In Progress` → `AI Review`（§12.5） |
+| 一部対応・人間判断待ち | `partial_fix` 等       | 原則 `In Progress` のまま          |
+| 別Issue化が必要        | `split_required`       | 原則 `In Progress` のまま          |
+| 対応不能               | `blocked` 等           | 原則 `In Progress` のまま          |
 
-| 状況                   | Status更新意図                            |
-| ---------------------- | ----------------------------------------- |
-| 指摘対応完了           | `In Progress` → `AI Review`               |
-| 一部対応・人間判断待ち | 原則 `In Progress` のまま                 |
-| 別Issue化が必要        | 原則 `In Progress` のまま                 |
-| 対応不能               | 原則 `In Progress` または運用ルールに従う |
+`ready_for_ai_review` 以外の場合は PR コメントのみ投稿し、**dispatch は実行しない**。
 
-Status更新は、Commandが直接確定するのではなく、GitHub Actionsまたは運用スクリプトが実施できるよう、更新意図として明確に出力する。
+---
+
+### 12.5 Projects Status 同期を起動する（`ready_for_ai_review` 時・必須）
+
+Fix 完了コメント投稿と `repository_dispatch` は **必ず同一 CLI** で実行する（`/review-pr` の §15.5 と同型）。  
+Status 更新はコメント投稿では自動検知しない。dispatch 忘れは Projects Status が `In Progress` のまま残る。
+
+**前提:** bot 認証（§0）済み、`GH_BOT_TOKEN` または `GITHUB_TOKEN` が利用可能であること。
+
+**推奨（コメント + dispatch を原子的に実行）:**
+
+```bash
+node .github/scripts/publish-fix-complete-and-dispatch.cjs \
+  --repository <owner>/<repo> \
+  --pr <PR番号> \
+  --comment-file path/to/fix-complete-comment.md
+```
+
+`Fix Outcome` はコメント §1 から自動抽出される。`ready_for_ai_review` のときのみ [PR再AI Review待ちStatus更新ワークフロー](../../docs/06_実装設計/github_actions/PR再AI%20Review待ちStatus更新ワークフロー仕様書.md) が dispatch される。
+
+**完了確認（dispatch 忘れチェック）:**
+
+```bash
+node .github/scripts/publish-fix-complete-and-dispatch.cjs \
+  --repository <owner>/<repo> \
+  --pr <PR番号> \
+  --verify
+```
+
+`ok: false` かつ `reason: dispatch_missing` の場合は、出力された `recovery_command` を実行する。
+
+**Recovery（コメント投稿済み・dispatch のみ再実行）:**
+
+```bash
+node .github/scripts/publish-fix-complete-and-dispatch.cjs \
+  --repository <owner>/<repo> \
+  --pr <PR番号> \
+  --comment-file path/to/fix-complete-comment.md \
+  --dispatch-only
+```
+
+**手動 recovery（workflow_dispatch）:**
+
+Actions → **PR Ready For AI Review Status Sync** → `pr_number` を指定して Run workflow。
+
+**低レベル API（非推奨・分離実行）:**
+
+```bash
+node .github/scripts/dispatch-pr-ready-for-ai-review.cjs \
+  --repository <owner>/<repo> \
+  --pr <PR番号> \
+  --fix-outcome ready_for_ai_review
+```
+
+dispatch が失敗した場合は、PR コメントは残るが Status は更新されない。`--dispatch-only` または `workflow_dispatch` で再実行する。
 
 ---
 
@@ -430,7 +484,7 @@ Slack通知は正本ではない。
 - 修正commitが作成されている
 - 未対応の指摘がある場合、理由が明記されている
 - 再レビュー可能な状態になっている
-- Statusを `AI Review` へ戻す意図が明確である
+- `ready_for_ai_review` の場合、`publish-fix-complete-and-dispatch.cjs` で dispatch 済み（または `--verify` で確認済み）
 - 次Commandとして `/review-pr` へ進める状態になっている
 
 ---
@@ -490,15 +544,14 @@ Slack通知は正本ではない。
 
 `/fix-review-comments` のStatus影響は以下とする。
 
-| 状況                   | Status更新意図                   |
-| ---------------------- | -------------------------------- |
-| 指摘対応完了           | `In Progress` → `AI Review`      |
-| 一部対応・人間判断待ち | `In Progress` のまま             |
-| 別Issue化が必要        | `In Progress` のまま             |
-| Contract Task化が必要  | `In Progress` のまま             |
-| 修正不能               | 運用ルールに従い、人間確認へ回す |
+| 状況                   | Fix Outcome           | Status更新                         |
+| ---------------------- | --------------------- | ---------------------------------- |
+| 指摘対応完了           | `ready_for_ai_review` | `In Progress` → `AI Review`（§12.5） |
+| 一部対応・人間判断待ち | `partial_fix` 等      | 原則 `In Progress` のまま          |
+| 別Issue化が必要        | `split_required`      | 原則 `In Progress` のまま          |
+| 修正不能               | `blocked` 等          | 運用ルールに従い、人間確認へ回す   |
 
-Status更新は、Commandが直接確定するのではなく、GitHub Actionsまたは運用スクリプトが実施できるよう、更新意図として明確に出力する。
+`ready_for_ai_review` の場合、§12.5 の **`publish-fix-complete-and-dispatch.cjs` を 1 回** 実行する。それ以外は PR コメントのみとし、dispatch しない。
 
 ---
 
@@ -598,7 +651,10 @@ Slack通知は正本ではない。
 -
 
 ### Status更新意図
-In Progress → AI Review
+In Progress → AI Review（`ready_for_ai_review` 時は §12.5 で workflow dispatch）
+
+### Fix Outcome
+ready_for_ai_review
 
 ### 次に実行するCommand
 /review-pr @<definition> #<PR番号>

--- a/.cursor/commands/fix-review-comments.md
+++ b/.cursor/commands/fix-review-comments.md
@@ -101,6 +101,15 @@ Definitionなしでの実行は原則禁止する。
 
 ## 処理手順
 
+### 0. Machine account 認証（GitHub 書き込み前・必須）
+
+push / commit の前に bot 認証を確認する（[github-operation.mdc](../../.cursor/rules/github-operation.mdc) §3.16）。
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
 ### 1. PRレビューコメントを確認する
 
 対象PRのレビューコメントを確認する。

--- a/.cursor/commands/review-pr.md
+++ b/.cursor/commands/review-pr.md
@@ -105,6 +105,15 @@ PRレビュー時は、特に以下を重視する。
 
 ## 処理手順
 
+### 0. Machine account 認証（GitHub 書き込み前・必須）
+
+commit / push / PR コメント / dispatch の前に bot 認証を確認する（[github-operation.mdc](../../.cursor/rules/github-operation.mdc) §3.16）。
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
 ### 1. PRを確認する
 
 対象PRを確認する。

--- a/.cursor/commands/start-task.md
+++ b/.cursor/commands/start-task.md
@@ -95,6 +95,15 @@ Definitionなしでの実行は原則禁止する。
 
 ## 処理手順
 
+### 0. Machine account 認証（GitHub 書き込み前・必須）
+
+Issue 作成 / Branch push / commit の前に bot 認証を確認する（[github-operation.mdc](../../.cursor/rules/github-operation.mdc) §3.16）。
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
 ### 1. Task Definitionを読み込む
 
 指定されたDefinitionを読み込む。

--- a/.cursor/commands/work-issue.md
+++ b/.cursor/commands/work-issue.md
@@ -85,6 +85,15 @@ Definitionなしでの実行は原則禁止する。
 
 ## 処理手順
 
+### 0. Machine account 認証（GitHub 書き込み前・必須）
+
+push / commit の前に bot 認証を確認する（[github-operation.mdc](../../.cursor/rules/github-operation.mdc) §3.16）。
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
 ### 1. Issueを確認する
 
 対象Issueを確認し、以下を整理する。

--- a/.cursor/rules/github-operation.mdc
+++ b/.cursor/rules/github-operation.mdc
@@ -384,6 +384,31 @@ AI Agentがcommitを作成する場合は、必ず `git-commit-message.mdc` を�
 - 自動生成結果が英語の場合は、人間またはAI Agentが日本語へ修正する
 - 最終的な強制は `.githooks/commit-msg` で行う
 
+### 3.16 Machine Account 認証（Human Review 前提）
+
+AI Agent が GitHub へ **書き込む** 操作（commit / push / Issue 作成 / PR 作成 / AI Review dispatch）を行う前に、**machine account**（`.github/ai-bot-account.json` の `machine_account_login`、現行: `okuri-ai-bot`）として認証すること。
+
+| 操作 | 認証 |
+| ---- | ---- |
+| commit / push / `gh issue create` / `gh pr create` | machine account PAT（`GH_BOT_TOKEN`） |
+| Human Review（Approve / Request changes）/ merge | 人間アカウント（`ryo-chan-k6`）。bot 認証を使わない |
+
+**作業開始前（必須）:**
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
+- PAT は **machine account で発行した Classic PAT**（`repo`）。人間アカウントの PAT では PR author が人間になり、Human Review 正式経路が使えない。
+- PAT は `~/.config/gift-recommend/gh-bot.env` に保管（`.github/gh-bot.env.example` 参照）。リポジトリに commit しない。
+- 詳細は [AI機械アカウント運用設計書](../../docs/00_共通/AIエージェント運用/AI機械アカウント運用設計書.md) を正とする。
+
+**禁止:**
+
+- 人間 PAT のまま `gh pr create` すること
+- machine account で Approve / Request changes / merge すること
+
 ---
 
 ## 4. 確認観点
@@ -478,6 +503,8 @@ AI Agentは、以下を行ってはならない。
 - 識別子付き Task で、Parent Epic と識別子 prefix が一致しない状態のまま Task を進めること
 - generatedファイル、OpenAPI、DB、CI/CDなど横断影響がある変更を通常Taskに無断で混在させること
 - secretや認証情報をIssue、PR、commit、Slack通知、ai-logsへ記載すること
+- 人間 PAT のまま PR を open すること（Human Review 不可になる）
+- machine account PAT（`GH_BOT_TOKEN`）をリポジトリへ commit すること
 - コミットメッセージ詳細ルールをこのRuleへ過剰に重複定義すること
 - worktree安全確認の詳細をこのRuleへ重複定義すること
 
@@ -549,6 +576,7 @@ AI Agentは、以下の場合、人間へ確認・報告する。
 | Task Definition設計書                      | 個別作業条件の構造                           |
 | Prompts運用ルール                          | `prompts/` 配下の配置・命名                  |
 | AIレビュー運用設計書                       | AI Reviewの品質観点                          |
+| AI機械アカウント運用設計書                 | machine account / PAT / Human Review 分離   |
 | AIログ運用ルール                           | `ai-logs/` の利用範囲                        |
 | Slack通知運用設計書                        | Slack通知タイミング・文面                    |
 | worktree運用ルール                         | 並列作業時の作業領域分離                     |

--- a/.github/ai-bot-account.json
+++ b/.github/ai-bot-account.json
@@ -1,0 +1,7 @@
+{
+  "machine_account_login": "okuri-ai-bot",
+  "human_reviewer_login": "ryo-chan-k6",
+  "token_env_var": "GH_BOT_TOKEN",
+  "env_file": "~/.config/gift-recommend/gh-bot.env",
+  "repository": "ryo-chan-k6/GiftRecommendAPP_MVP_CYCLE_3"
+}

--- a/.github/gh-bot.env.example
+++ b/.github/gh-bot.env.example
@@ -1,0 +1,4 @@
+# Copy to ~/.config/gift-recommend/gh-bot.env (chmod 600).
+# Machine account: see .github/ai-bot-account.json
+# Do not commit gh-bot.env or PAT values.
+export GH_BOT_TOKEN=ghp_your_token_here

--- a/.github/scripts/dispatch-pr-ready-for-ai-review.cjs
+++ b/.github/scripts/dispatch-pr-ready-for-ai-review.cjs
@@ -1,0 +1,189 @@
+"use strict";
+
+const slack = require("./slack-notify.cjs");
+
+const EVENT_TYPE = "fix_ready_for_ai_review";
+
+function nonEmpty(value) {
+  return String(value || "").trim();
+}
+
+function resolveRepository({ owner, repo, repository }) {
+  if (owner && repo) return { owner: nonEmpty(owner), repo: nonEmpty(repo) };
+  const full = nonEmpty(repository) || nonEmpty(process.env.GITHUB_REPOSITORY);
+  if (!full || !full.includes("/")) {
+    throw new Error("repository is required (--owner/--repo or GITHUB_REPOSITORY)");
+  }
+  const [resolvedOwner, resolvedRepo] = full.split("/", 2);
+  return { owner: resolvedOwner, repo: resolvedRepo };
+}
+
+function buildClientPayload({ prNumber, fixOutcome, fixBody }) {
+  const normalized = slack.normalizeKnownFixOutcome(fixOutcome);
+  if (!normalized) {
+    throw new Error(
+      `Invalid fix_outcome: ${fixOutcome}. Use ready_for_ai_review, needs_human_decision, split_required, partial_fix, or blocked.`,
+    );
+  }
+  const pr = Number(prNumber);
+  if (!Number.isInteger(pr) || pr <= 0) {
+    throw new Error(`Invalid pr_number: ${prNumber}`);
+  }
+  const payload = {
+    pr_number: String(pr),
+    fix_outcome: normalized,
+  };
+  const body = nonEmpty(fixBody);
+  if (body) payload.fix_body = body;
+  return payload;
+}
+
+function dispatchUrl(owner, repo) {
+  return `https://api.github.com/repos/${owner}/${repo}/dispatches`;
+}
+
+async function dispatchPrReadyForAiReview({
+  owner,
+  repo,
+  repository,
+  prNumber,
+  fixOutcome,
+  fixBody,
+  token,
+  dryRun,
+  fetchImpl,
+}) {
+  const resolved = resolveRepository({ owner, repo, repository });
+  const authToken = nonEmpty(token) || nonEmpty(process.env.GITHUB_TOKEN) || nonEmpty(process.env.GH_TOKEN);
+  if (!authToken) {
+    throw new Error("GITHUB_TOKEN or GH_TOKEN is required to dispatch repository_dispatch");
+  }
+  const clientPayload = buildClientPayload({ prNumber, fixOutcome, fixBody });
+  if (dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      eventType: EVENT_TYPE,
+      owner: resolved.owner,
+      repo: resolved.repo,
+      clientPayload,
+    };
+  }
+
+  const send = fetchImpl || global.fetch;
+  if (typeof send !== "function") {
+    throw new Error("fetch is unavailable");
+  }
+
+  const response = await send(dispatchUrl(resolved.owner, resolved.repo), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: JSON.stringify({
+      event_type: EVENT_TYPE,
+      client_payload: clientPayload,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`repository_dispatch failed: HTTP ${response.status} ${text}`.trim());
+  }
+
+  return {
+    ok: true,
+    eventType: EVENT_TYPE,
+    owner: resolved.owner,
+    repo: resolved.repo,
+    clientPayload,
+  };
+}
+
+function parseCliArgs(argv) {
+  const args = argv.slice(2);
+  const options = {
+    owner: "",
+    repo: "",
+    repository: "",
+    prNumber: "",
+    fixOutcome: "ready_for_ai_review",
+    fixBody: "",
+    dryRun: false,
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--owner") {
+      options.owner = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repository" || arg === "-R") {
+      options.repository = args[++i] || "";
+      continue;
+    }
+    if (arg === "--pr" || arg === "--pr-number") {
+      options.prNumber = args[++i] || "";
+      continue;
+    }
+    if (arg === "--fix-outcome") {
+      options.fixOutcome = args[++i] || "";
+      continue;
+    }
+    if (arg === "--fix-body-file") {
+      const fs = require("fs");
+      const filePath = args[++i] || "";
+      options.fixBody = fs.readFileSync(filePath, "utf8");
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node .github/scripts/dispatch-pr-ready-for-ai-review.cjs \\
+    --pr <number> [--fix-outcome ready_for_ai_review] \\
+    [--repository owner/repo] [--fix-body-file path] [--dry-run]
+
+Dispatches repository event "${EVENT_TYPE}" to run PR ready-for-AI-review status sync once.
+`);
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv);
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  const result = await dispatchPrReadyForAiReview(options);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  EVENT_TYPE,
+  buildClientPayload,
+  dispatchPrReadyForAiReview,
+};

--- a/.github/scripts/dispatch-pr-ready-for-ai-review.test.cjs
+++ b/.github/scripts/dispatch-pr-ready-for-ai-review.test.cjs
@@ -1,0 +1,38 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const dispatch = require("./dispatch-pr-ready-for-ai-review.cjs");
+
+test("buildClientPayload: ready_for_ai_reviewを正規化する", () => {
+  const payload = dispatch.buildClientPayload({
+    prNumber: 10,
+    fixOutcome: "ready_for_ai_review",
+  });
+  assert.equal(payload.pr_number, "10");
+  assert.equal(payload.fix_outcome, "ready_for_ai_review");
+});
+
+test("buildClientPayload: 不正なfix_outcomeは拒否する", () => {
+  assert.throws(
+    () => dispatch.buildClientPayload({ prNumber: 10, fixOutcome: "invalid" }),
+    /Invalid fix_outcome/,
+  );
+});
+
+test("dispatchPrReadyForAiReview: dry_runではAPIを呼ばない", async () => {
+  let called = 0;
+  const result = await dispatch.dispatchPrReadyForAiReview({
+    repository: "o/r",
+    prNumber: 10,
+    fixOutcome: "ready_for_ai_review",
+    token: "t",
+    dryRun: true,
+    fetchImpl: async () => {
+      called += 1;
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.eventType, "fix_ready_for_ai_review");
+  assert.equal(called, 0);
+});

--- a/.github/scripts/e2e-bot-author-test-pr.sh
+++ b/.github/scripts/e2e-bot-author-test-pr.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(diname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+CONFIG_JSON="$(node -e "const c=require('./.github/ai-bot-account.json'); console.log([c.machine_account_login,c.repository||'ryo-chan-k6/GiftRecommendAPP_MVP_CYCLE_3'].join('|'))")"
+BOT_USER="${CONFIG_JSON%%|*}"
+REPO="${CONFIG_JSON#*|}"
+BRANCH="test/bot-author-human-review-e2e"
+BASE="develop"
+
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+GIT_USER_JSON="$(node .github/scripts/gh-bot-auth.cjs print-git-user)"
+GIT_NAME="$(node -e "console.log(JSON.parse(process.argv[1]).name)" "$GIT_USER_JSON")"
+GIT_EMAIL="$(node -e "console.log(JSON.parse(process.argv[1]).email)" "$GIT_USER_JSON")"
+
+TOKEN="${GH_BOT_TOKEN:?GH_BOT_TOKEN is required}"
+
+git fetch origin "$BASE"
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git checkout "$BRANCH"
+else
+  git checkout -B "$BRANCH" "origin/$BASE"
+fi
+
+git add ai-logs/experiments/2026-05-30-bot-author-human-review-e2e.md
+if git diff --cached --quiet; then
+  echo "No staged changes (file may already be committed)."
+else
+  git -c "user.name=$GIT_NAME" -c "user.email=$GIT_EMAIL" commit -m "$(cat <<EOF
+test: bot author Human Review E2E用マーカー
+
+${BOT_USER} が PR author になることを確認する。
+EOF
+)"
+fi
+
+git push "https://x-access-token:${TOKEN}@github.com/${REPO}.git" "HEAD:${BRANCH}"
+
+PR_URL="$(gh pr create \
+  --repo "$REPO" \
+  --base "$BASE" \
+  --head "$BRANCH" \
+  --title "test: bot author Human Review E2E" \
+  --body "$(cat <<EOF
+## 概要
+
+\`${BOT_USER}\` が PR author となり、\`ryo-chan-k6\` が Human Review（Approve / Request changes）できることを確認する E2E 用 PR。
+
+## 確認手順
+
+1. PR author が \`${BOT_USER}\` であること
+2. \`ryo-chan-k6\` で Review changes → Approve / Request changes が選択できること
+
+## 後片付け
+
+検証後 Close 可（merge 不要）。
+EOF
+)")"
+
+PR_NUM="$(gh pr view "$PR_URL" --json number --jq .number)"
+AUTHOR="$(gh pr view "$PR_NUM" --repo "$REPO" --json author --jq .author.login)"
+
+echo ""
+echo "PR: $PR_URL"
+echo "PR number: #$PR_NUM"
+echo "Author: $AUTHOR"
+
+if [[ "$AUTHOR" != "$BOT_USER" ]]; then
+  echo "ERROR: PR author is not $BOT_USER" >&2
+  exit 1
+fi
+
+echo "SUCCESS: PR author is $BOT_USER. Human Review test on GitHub Web as ryo-chan-k6."

--- a/.github/scripts/gh-bot-auth.cjs
+++ b/.github/scripts/gh-bot-auth.cjs
@@ -1,0 +1,219 @@
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const DEFAULT_CONFIG_PATH = path.join(__dirname, "..", "ai-bot-account.json");
+
+function nonEmpty(value) {
+  return String(value || "").trim();
+}
+
+function expandHome(filePath) {
+  const text = nonEmpty(filePath);
+  if (!text.startsWith("~")) return text;
+  return path.join(os.homedir(), text.slice(1).replace(/^[/\\]/, ""));
+}
+
+function loadBotAccountConfig(configPath = DEFAULT_CONFIG_PATH) {
+  const resolved = path.resolve(configPath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`Bot account config not found: ${resolved}`);
+  }
+  const config = JSON.parse(fs.readFileSync(resolved, "utf8"));
+  const login = nonEmpty(config.machine_account_login);
+  if (!login) {
+    throw new Error("machine_account_login is required in ai-bot-account.json");
+  }
+  return {
+    machineAccountLogin: login,
+    humanReviewerLogin: nonEmpty(config.human_reviewer_login),
+    tokenEnvVar: nonEmpty(config.token_env_var) || "GH_BOT_TOKEN",
+    envFile: expandHome(config.env_file || "~/.config/gift-recommend/gh-bot.env"),
+    repository: nonEmpty(config.repository),
+    configPath: resolved,
+  };
+}
+
+function parseEnvFile(content, tokenEnvVar) {
+  const vars = {};
+  for (const rawLine of String(content || "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const exportMatch = /^export\s+([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+    const plainMatch = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+    const match = exportMatch || plainMatch;
+    if (!match) continue;
+    const key = match[1];
+    let value = match[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    vars[key] = value;
+  }
+  return vars[tokenEnvVar] || "";
+}
+
+function loadTokenFromEnvFile(envFile, tokenEnvVar) {
+  if (!envFile || !fs.existsSync(envFile)) return "";
+  return parseEnvFile(fs.readFileSync(envFile, "utf8"), tokenEnvVar);
+}
+
+function resolveBotToken({ config, tokenOverride } = {}) {
+  const cfg = config || loadBotAccountConfig();
+  const fromOverride = nonEmpty(tokenOverride);
+  if (fromOverride) return fromOverride;
+  const fromProcess = nonEmpty(process.env[cfg.tokenEnvVar]);
+  if (fromProcess) return fromProcess;
+  return loadTokenFromEnvFile(cfg.envFile, cfg.tokenEnvVar);
+}
+
+function authHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function fetchGitHubLogin({ token, fetchImpl }) {
+  const send = fetchImpl || global.fetch;
+  if (typeof send !== "function") {
+    throw new Error("fetch is unavailable");
+  }
+  const response = await send("https://api.github.com/user", {
+    headers: authHeaders(token),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`GitHub API /user failed: HTTP ${response.status} ${text}`.trim());
+  }
+  const data = await response.json();
+  return {
+    login: nonEmpty(data.login),
+    id: data.id,
+  };
+}
+
+async function verifyBotAuth({
+  config,
+  token,
+  fetchImpl,
+} = {}) {
+  const cfg = config || loadBotAccountConfig();
+  const resolvedToken = resolveBotToken({ config: cfg, tokenOverride: token });
+  if (!resolvedToken) {
+    return {
+      ok: false,
+      reason: "token_missing",
+      message: `${cfg.tokenEnvVar} is not set. Create ${cfg.envFile} (see .github/gh-bot.env.example).`,
+      config: cfg,
+    };
+  }
+
+  let loginInfo;
+  try {
+    loginInfo = await fetchGitHubLogin({ token: resolvedToken, fetchImpl });
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "api_error",
+      message: error.message,
+      config: cfg,
+    };
+  }
+
+  if (loginInfo.login !== cfg.machineAccountLogin) {
+    return {
+      ok: false,
+      reason: "wrong_login",
+      message: `Expected machine account ${cfg.machineAccountLogin} but authenticated as ${loginInfo.login}. Use the bot Classic PAT, not the human account token.`,
+      login: loginInfo.login,
+      config: cfg,
+    };
+  }
+
+  return {
+    ok: true,
+    login: loginInfo.login,
+    id: loginInfo.id,
+    token: resolvedToken,
+    gitUser: {
+      name: loginInfo.login,
+      email: `${loginInfo.id}+${loginInfo.login}@users.noreply.github.com`,
+    },
+    config: cfg,
+  };
+}
+
+function formatShellSetup(result) {
+  const cfg = result.config;
+  return [
+    `# Machine account auth (${cfg.machineAccountLogin})`,
+    `source ${cfg.envFile} 2>/dev/null || true`,
+    `export GH_TOKEN="$${cfg.tokenEnvVar}"`,
+    `export GITHUB_TOKEN="$${cfg.tokenEnvVar}"`,
+    `# verify: gh api user --jq .login  # => ${cfg.machineAccountLogin}`,
+  ].join("\n");
+}
+
+async function main(argv) {
+  const args = argv.slice(2);
+  const command = args[0] || "verify";
+
+  if (command === "verify") {
+    const result = await verifyBotAuth();
+    if (!result.ok) {
+      console.error(result.message);
+      process.exit(1);
+    }
+    console.log(`OK: authenticated as ${result.login}`);
+    if (result.config.humanReviewerLogin) {
+      console.log(`Human Reviewer: ${result.config.humanReviewerLogin}`);
+    }
+    return;
+  }
+
+  if (command === "print-setup") {
+    const result = await verifyBotAuth();
+    if (!result.ok) {
+      console.error(result.message);
+      process.exit(1);
+    }
+    console.log(formatShellSetup(result));
+    return;
+  }
+
+  if (command === "print-git-user") {
+    const result = await verifyBotAuth();
+    if (!result.ok) {
+      console.error(result.message);
+      process.exit(1);
+    }
+    console.log(JSON.stringify(result.gitUser));
+    return;
+  }
+
+  console.error(`Unknown command: ${command}. Use verify | print-setup | print-git-user`);
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main(process.argv).catch((error) => {
+    console.error(error.message || error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  DEFAULT_CONFIG_PATH,
+  loadBotAccountConfig,
+  resolveBotToken,
+  verifyBotAuth,
+  formatShellSetup,
+  expandHome,
+};

--- a/.github/scripts/gh-bot-auth.test.cjs
+++ b/.github/scripts/gh-bot-auth.test.cjs
@@ -1,0 +1,84 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { test } = require("node:test");
+
+const ghBotAuth = require("./gh-bot-auth.cjs");
+
+test("expandHome expands tilde path", () => {
+  assert.match(ghBotAuth.expandHome("~/foo/bar"), new RegExp(`${os.homedir()}[/\\\\]foo[/\\\\]bar$`));
+});
+
+test("loadBotAccountConfig reads machine account login", () => {
+  const config = ghBotAuth.loadBotAccountConfig();
+  assert.equal(config.machineAccountLogin, "okuri-ai-bot");
+  assert.equal(config.humanReviewerLogin, "ryo-chan-k6");
+});
+
+test("resolveBotToken prefers explicit override", () => {
+  const config = ghBotAuth.loadBotAccountConfig();
+  assert.equal(ghBotAuth.resolveBotToken({ config, tokenOverride: "ghp_test" }), "ghp_test");
+});
+
+test("verifyBotAuth fails when token missing", async () => {
+  const config = ghBotAuth.loadBotAccountConfig();
+  const result = await ghBotAuth.verifyBotAuth({
+    config: { ...config, envFile: "/tmp/nonexistent-gh-bot.env", tokenEnvVar: "GH_BOT_TOKEN" },
+    token: "",
+    fetchImpl: async () => ({ ok: true, json: async () => ({ login: "okuri-ai-bot", id: 1 }) }),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "token_missing");
+});
+
+test("verifyBotAuth fails on wrong login", async () => {
+  const config = ghBotAuth.loadBotAccountConfig();
+  const result = await ghBotAuth.verifyBotAuth({
+    config,
+    token: "ghp_test",
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({ login: "ryo-chan-k6", id: 2 }),
+    }),
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "wrong_login");
+});
+
+test("verifyBotAuth succeeds for configured machine account", async () => {
+  const config = ghBotAuth.loadBotAccountConfig();
+  const result = await ghBotAuth.verifyBotAuth({
+    config,
+    token: "ghp_test",
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({ login: "okuri-ai-bot", id: 99 }),
+    }),
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.login, "okuri-ai-bot");
+  assert.equal(result.gitUser.email, "99+okuri-ai-bot@users.noreply.github.com");
+});
+
+test("resolveBotToken reads env file", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "gh-bot-env-"));
+  const envFile = path.join(dir, "gh-bot.env");
+  fs.writeFileSync(envFile, 'export GH_BOT_TOKEN="ghp_from_file"\n', "utf8");
+  const config = {
+    ...ghBotAuth.loadBotAccountConfig(),
+    envFile,
+    tokenEnvVar: "GH_BOT_TOKEN",
+  };
+  const previous = process.env.GH_BOT_TOKEN;
+  delete process.env.GH_BOT_TOKEN;
+  try {
+    assert.equal(ghBotAuth.resolveBotToken({ config }), "ghp_from_file");
+  } finally {
+    if (previous === undefined) delete process.env.GH_BOT_TOKEN;
+    else process.env.GH_BOT_TOKEN = previous;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/.github/scripts/publish-fix-complete-and-dispatch.cjs
+++ b/.github/scripts/publish-fix-complete-and-dispatch.cjs
@@ -1,0 +1,457 @@
+"use strict";
+
+const fs = require("fs");
+const slack = require("./slack-notify.cjs");
+const dispatch = require("./dispatch-pr-ready-for-ai-review.cjs");
+
+const READY_FOR_AI_REVIEW_WORKFLOW_FILE = "pr-ready-for-ai-review.yml";
+const DISPATCH_RUN_TITLE_RE = /fix-ready · dispatch · PR #(\d+)/;
+
+function nonEmpty(value) {
+  return String(value || "").trim();
+}
+
+function resolveRepository({ owner, repo, repository }) {
+  if (owner && repo) return { owner: nonEmpty(owner), repo: nonEmpty(repo) };
+  const full = nonEmpty(repository) || nonEmpty(process.env.GITHUB_REPOSITORY);
+  if (!full || !full.includes("/")) {
+    throw new Error("repository is required (--owner/--repo or GITHUB_REPOSITORY)");
+  }
+  const [resolvedOwner, resolvedRepo] = full.split("/", 2);
+  return { owner: resolvedOwner, repo: resolvedRepo };
+}
+
+function readCommentBody({ commentBody, commentFile }) {
+  if (nonEmpty(commentBody)) return commentBody;
+  if (nonEmpty(commentFile)) return fs.readFileSync(commentFile, "utf8");
+  throw new Error("comment body is required (--comment-body or --comment-file)");
+}
+
+function resolveFixOutcome({ commentBody, fixOutcomeOverride }) {
+  const override = nonEmpty(fixOutcomeOverride);
+  if (override) {
+    const normalized = slack.normalizeKnownFixOutcome(fixOutcomeOverride);
+    if (!normalized) {
+      throw new Error(`Invalid fix_outcome override: ${fixOutcomeOverride}`);
+    }
+    return normalized;
+  }
+  const extracted = slack.extractFixOutcomeFromComment(commentBody);
+  if (!extracted.ok) {
+    const reason =
+      extracted.reason === "not_fix_complete_comment"
+        ? "Comment is not fix-complete-comment format (§1 Fix Outcome required)."
+        : "Fix Outcome not found in comment.";
+    throw new Error(reason);
+  }
+  return extracted.value;
+}
+
+function authHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "Content-Type": "application/json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function postPullRequestComment({
+  owner,
+  repo,
+  prNumber,
+  body,
+  token,
+  dryRun,
+  fetchImpl,
+}) {
+  const pr = Number(prNumber);
+  if (!Number.isInteger(pr) || pr <= 0) {
+    throw new Error(`Invalid pr_number: ${prNumber}`);
+  }
+  if (dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      html_url: `https://github.com/${owner}/${repo}/pull/${pr}#dry-run-comment`,
+    };
+  }
+  const send = fetchImpl || global.fetch;
+  if (typeof send !== "function") {
+    throw new Error("fetch is unavailable");
+  }
+  const response = await send(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${pr}/comments`,
+    {
+      method: "POST",
+      headers: authHeaders(token),
+      body: JSON.stringify({ body }),
+    },
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Failed to post PR comment: HTTP ${response.status} ${text}`.trim());
+  }
+  const data = await response.json();
+  return { ok: true, html_url: data.html_url || "", id: data.id };
+}
+
+function buildRecoveryCommand({ owner, repo, prNumber, fixOutcome, commentFile }) {
+  const repoArg = `--repository ${owner}/${repo}`;
+  const parts = [
+    "node .github/scripts/publish-fix-complete-and-dispatch.cjs",
+    repoArg,
+    `--pr ${prNumber}`,
+    `--fix-outcome ${fixOutcome}`,
+    "--dispatch-only",
+  ];
+  if (commentFile) parts.push(`--comment-file ${commentFile}`);
+  return parts.join(" \\\n  ");
+}
+
+async function publishFixCompleteAndDispatch({
+  owner,
+  repo,
+  repository,
+  prNumber,
+  commentBody,
+  commentFile,
+  fixOutcome,
+  token,
+  dryRun,
+  dispatchOnly,
+  fetchImpl,
+}) {
+  const resolved = resolveRepository({ owner, repo, repository });
+  const authToken = nonEmpty(token) || nonEmpty(process.env.GITHUB_TOKEN) || nonEmpty(process.env.GH_TOKEN);
+  if (!authToken) {
+    throw new Error("GITHUB_TOKEN or GH_TOKEN is required");
+  }
+
+  const body = readCommentBody({ commentBody, commentFile });
+  const normalizedOutcome = resolveFixOutcome({ commentBody: body, fixOutcomeOverride: fixOutcome });
+
+  let commentResult = null;
+  if (!dispatchOnly) {
+    if (!slack.isFixCompleteResultComment(body)) {
+      throw new Error(
+        "Comment is not fix-complete-comment format. Use prompts/templates/review/fix-complete-comment.md.",
+      );
+    }
+    commentResult = await postPullRequestComment({
+      owner: resolved.owner,
+      repo: resolved.repo,
+      prNumber,
+      body,
+      token: authToken,
+      dryRun,
+      fetchImpl,
+    });
+  }
+
+  if (normalizedOutcome !== "ready_for_ai_review") {
+    return {
+      ok: true,
+      owner: resolved.owner,
+      repo: resolved.repo,
+      pr_number: String(prNumber),
+      fix_outcome: normalizedOutcome,
+      comment: commentResult,
+      dispatch: null,
+      dispatch_skipped: true,
+      dispatch_skip_reason: "fix_outcome_not_ready_for_ai_review",
+      dispatch_only: Boolean(dispatchOnly),
+    };
+  }
+
+  try {
+    const dispatchResult = await dispatch.dispatchPrReadyForAiReview({
+      owner: resolved.owner,
+      repo: resolved.repo,
+      prNumber,
+      fixOutcome: normalizedOutcome,
+      fixBody: body,
+      token: authToken,
+      dryRun,
+      fetchImpl,
+    });
+    return {
+      ok: true,
+      owner: resolved.owner,
+      repo: resolved.repo,
+      pr_number: String(prNumber),
+      fix_outcome: normalizedOutcome,
+      comment: commentResult,
+      dispatch: dispatchResult,
+      dispatch_skipped: false,
+      dispatch_only: Boolean(dispatchOnly),
+    };
+  } catch (error) {
+    if (commentResult && !dryRun) {
+      error.recoveryCommand = buildRecoveryCommand({
+        owner: resolved.owner,
+        repo: resolved.repo,
+        prNumber,
+        fixOutcome: normalizedOutcome,
+        commentFile,
+      });
+      error.message = `${error.message}\n\nPR comment was posted but dispatch failed. Re-run dispatch only:\n${error.recoveryCommand}`;
+    }
+    throw error;
+  }
+}
+
+async function listIssueComments({ owner, repo, prNumber, token, fetchImpl }) {
+  const send = fetchImpl || global.fetch;
+  const response = await send(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/comments?per_page=100`,
+    { headers: authHeaders(token) },
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Failed to list PR comments: HTTP ${response.status} ${text}`.trim());
+  }
+  return response.json();
+}
+
+async function listFixReadyDispatchRuns({ owner, repo, token, fetchImpl, perPage = 30 }) {
+  const send = fetchImpl || global.fetch;
+  const response = await send(
+    `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${READY_FOR_AI_REVIEW_WORKFLOW_FILE}/runs?event=repository_dispatch&per_page=${perPage}`,
+    { headers: authHeaders(token) },
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Failed to list workflow runs: HTTP ${response.status} ${text}`.trim());
+  }
+  const data = await response.json();
+  return data.workflow_runs || [];
+}
+
+function findLatestFixCompleteComment(comments) {
+  const sorted = [...(comments || [])].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+  return sorted.find((comment) => {
+    if (!slack.isFixCompleteResultComment(comment.body || "")) return false;
+    const extracted = slack.extractFixOutcomeFromComment(comment.body || "");
+    return extracted.ok && extracted.value === "ready_for_ai_review";
+  });
+}
+
+function findDispatchRunAfterComment({ runs, prNumber, sinceIso }) {
+  const since = new Date(sinceIso).getTime();
+  const pr = String(prNumber);
+  return (runs || []).find((run) => {
+    const title = String(run.display_title || run.name || "");
+    const match = DISPATCH_RUN_TITLE_RE.exec(title);
+    if (!match || match[1] !== pr) return false;
+    const created = new Date(run.created_at).getTime();
+    if (Number.isNaN(created) || created < since) return false;
+    return run.status === "completed" && run.conclusion === "success";
+  });
+}
+
+async function verifyFixCompleteDispatch({
+  owner,
+  repo,
+  repository,
+  prNumber,
+  token,
+  fetchImpl,
+  listComments = listIssueComments,
+  listRuns = listFixReadyDispatchRuns,
+}) {
+  const resolved = resolveRepository({ owner, repo, repository });
+  const authToken = nonEmpty(token) || nonEmpty(process.env.GITHUB_TOKEN) || nonEmpty(process.env.GH_TOKEN);
+  if (!authToken) {
+    throw new Error("GITHUB_TOKEN or GH_TOKEN is required");
+  }
+
+  const comments = await listComments({
+    owner: resolved.owner,
+    repo: resolved.repo,
+    prNumber,
+    token: authToken,
+    fetchImpl,
+  });
+  const latestFixComment = findLatestFixCompleteComment(comments);
+  if (!latestFixComment) {
+    return {
+      ok: false,
+      reason: "no_fix_complete_comment",
+      message: "No fix-complete comment with ready_for_ai_review found on PR.",
+    };
+  }
+
+  const extracted = slack.extractFixOutcomeFromComment(latestFixComment.body || "");
+  const runs = await listRuns({
+    owner: resolved.owner,
+    repo: resolved.repo,
+    token: authToken,
+    fetchImpl,
+  });
+  const matchedRun = findDispatchRunAfterComment({
+    runs,
+    prNumber,
+    sinceIso: latestFixComment.created_at,
+  });
+
+  if (!matchedRun) {
+    const recovery = buildRecoveryCommand({
+      owner: resolved.owner,
+      repo: resolved.repo,
+      prNumber,
+      fixOutcome: extracted.ok ? extracted.value : "ready_for_ai_review",
+    });
+    return {
+      ok: false,
+      reason: "dispatch_missing",
+      message: "Fix-complete comment exists but no successful fix-ready dispatch run found after it.",
+      latest_fix_complete_comment_url: latestFixComment.html_url || "",
+      latest_fix_complete_comment_at: latestFixComment.created_at || "",
+      recovery_command: recovery,
+    };
+  }
+
+  return {
+    ok: true,
+    pr_number: String(prNumber),
+    latest_fix_complete_comment_url: latestFixComment.html_url || "",
+    latest_fix_complete_comment_at: latestFixComment.created_at || "",
+    dispatch_run_id: matchedRun.id,
+    dispatch_run_url: matchedRun.html_url || "",
+    dispatch_run_title: matchedRun.display_title || matchedRun.name || "",
+    fix_outcome: extracted.ok ? extracted.value : "",
+  };
+}
+
+function parseCliArgs(argv) {
+  const args = argv.slice(2);
+  const options = {
+    owner: "",
+    repo: "",
+    repository: "",
+    prNumber: "",
+    commentBody: "",
+    commentFile: "",
+    fixOutcome: "",
+    dryRun: false,
+    dispatchOnly: false,
+    verifyOnly: false,
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--dispatch-only") {
+      options.dispatchOnly = true;
+      continue;
+    }
+    if (arg === "--verify") {
+      options.verifyOnly = true;
+      continue;
+    }
+    if (arg === "--owner") {
+      options.owner = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repository" || arg === "-R") {
+      options.repository = args[++i] || "";
+      continue;
+    }
+    if (arg === "--pr" || arg === "--pr-number") {
+      options.prNumber = args[++i] || "";
+      continue;
+    }
+    if (arg === "--fix-outcome") {
+      options.fixOutcome = args[++i] || "";
+      continue;
+    }
+    if (arg === "--comment-body") {
+      options.commentBody = args[++i] || "";
+      continue;
+    }
+    if (arg === "--comment-file") {
+      options.commentFile = args[++i] || "";
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  # Post fix-complete comment and dispatch status sync (recommended)
+  node .github/scripts/publish-fix-complete-and-dispatch.cjs \\
+    --repository owner/repo --pr <number> --comment-file path/to/fix-complete-comment.md
+
+  # Recovery: dispatch only (comment already posted)
+  node .github/scripts/publish-fix-complete-and-dispatch.cjs \\
+    --repository owner/repo --pr <number> --fix-outcome ready_for_ai_review \\
+    --comment-file path/to/fix-complete-comment.md --dispatch-only
+
+  # Verify dispatch was not forgotten
+  node .github/scripts/publish-fix-complete-and-dispatch.cjs \\
+    --repository owner/repo --pr <number> --verify
+`);
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv);
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  if (!options.prNumber) {
+    throw new Error("--pr is required");
+  }
+
+  if (options.verifyOnly) {
+    const result = await verifyFixCompleteDispatch(options);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    if (!result.ok) process.exitCode = 1;
+    return;
+  }
+
+  if (options.dispatchOnly) {
+    if (!options.fixOutcome && !options.commentFile && !options.commentBody) {
+      throw new Error("--dispatch-only requires --fix-outcome or --comment-file");
+    }
+  } else if (!options.commentFile && !options.commentBody) {
+    throw new Error("--comment-file or --comment-body is required (unless --dispatch-only or --verify)");
+  }
+
+  const result = await publishFixCompleteAndDispatch(options);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  READY_FOR_AI_REVIEW_WORKFLOW_FILE,
+  DISPATCH_RUN_TITLE_RE,
+  resolveFixOutcome,
+  postPullRequestComment,
+  publishFixCompleteAndDispatch,
+  verifyFixCompleteDispatch,
+  findLatestFixCompleteComment,
+  findDispatchRunAfterComment,
+  buildRecoveryCommand,
+};

--- a/.github/scripts/publish-fix-complete-and-dispatch.test.cjs
+++ b/.github/scripts/publish-fix-complete-and-dispatch.test.cjs
@@ -1,0 +1,164 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const publish = require("./publish-fix-complete-and-dispatch.cjs");
+
+const SAMPLE_COMMENT = `# Fix Review Comments Result
+
+## 1. 対応結果
+
+| 項目 | 内容 |
+| ---- | ---- |
+| Fix Outcome | \`ready_for_ai_review\` |
+| 対象PR | \`#10\` |
+
+## 12. Status更新意図
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 次Status | \`AI Review\` |
+`;
+
+test("resolveFixOutcome: コメントからFix Outcomeを抽出する", () => {
+  const value = publish.resolveFixOutcome({ commentBody: SAMPLE_COMMENT });
+  assert.equal(value, "ready_for_ai_review");
+});
+
+test("resolveFixOutcome: overrideが優先される", () => {
+  const value = publish.resolveFixOutcome({
+    commentBody: SAMPLE_COMMENT,
+    fixOutcomeOverride: "split_required",
+  });
+  assert.equal(value, "split_required");
+});
+
+test("publishFixCompleteAndDispatch: dry_runではAPIを呼ばない", async () => {
+  let called = 0;
+  const result = await publish.publishFixCompleteAndDispatch({
+    repository: "o/r",
+    prNumber: 10,
+    commentBody: SAMPLE_COMMENT,
+    token: "t",
+    dryRun: true,
+    fetchImpl: async () => {
+      called += 1;
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.fix_outcome, "ready_for_ai_review");
+  assert.equal(called, 0);
+});
+
+test("publishFixCompleteAndDispatch: ready_for_ai_reviewはコメント投稿後にdispatchする", async () => {
+  const calls = [];
+  const result = await publish.publishFixCompleteAndDispatch({
+    repository: "o/r",
+    prNumber: 10,
+    commentBody: SAMPLE_COMMENT,
+    token: "t",
+    fetchImpl: async (url, options) => {
+      calls.push({ url, method: options.method });
+      if (url.includes("/issues/10/comments") && options.method === "POST") {
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({ html_url: "https://example.com/comment/1", id: 1 }),
+        };
+      }
+      if (url.includes("/dispatches")) {
+        return { ok: true, status: 204, async text() { return ""; } };
+      }
+      throw new Error(`unexpected url: ${url}`);
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.dispatch_skipped, false);
+  assert.equal(calls.length, 2);
+  assert.match(calls[0].url, /issues\/10\/comments$/);
+  assert.match(calls[1].url, /dispatches$/);
+});
+
+test("publishFixCompleteAndDispatch: split_requiredはdispatchしない", async () => {
+  const body = SAMPLE_COMMENT.replace("ready_for_ai_review", "split_required");
+  let dispatchCalled = false;
+  const result = await publish.publishFixCompleteAndDispatch({
+    repository: "o/r",
+    prNumber: 10,
+    commentBody: body,
+    token: "t",
+    fetchImpl: async (url, options) => {
+      if (url.includes("/dispatches")) dispatchCalled = true;
+      if (url.includes("/issues/10/comments")) {
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({ html_url: "https://example.com/comment/1", id: 1 }),
+        };
+      }
+      throw new Error(url);
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.dispatch_skipped, true);
+  assert.equal(dispatchCalled, false);
+});
+
+test("publishFixCompleteAndDispatch: dispatch失敗時にrecoveryCommandを付与する", async () => {
+  await assert.rejects(
+    () =>
+      publish.publishFixCompleteAndDispatch({
+        repository: "o/r",
+        prNumber: 10,
+        commentBody: SAMPLE_COMMENT,
+        commentFile: "/tmp/fix-complete.md",
+        token: "t",
+        fetchImpl: async (url, options) => {
+          if (url.includes("/issues/10/comments")) {
+            return {
+              ok: true,
+              status: 201,
+              json: async () => ({ html_url: "https://example.com/comment/1", id: 1 }),
+            };
+          }
+          if (url.includes("/dispatches")) {
+            return { ok: false, status: 403, text: async () => "forbidden" };
+          }
+          throw new Error(url);
+        },
+      }),
+    (error) => {
+      assert.match(error.message, /dispatch failed/i);
+      assert.match(error.recoveryCommand, /--dispatch-only/);
+      assert.match(error.recoveryCommand, /--comment-file/);
+      return true;
+    },
+  );
+});
+
+test("verifyFixCompleteDispatch: dispatch済みならok", async () => {
+  const result = await publish.verifyFixCompleteDispatch({
+    repository: "o/r",
+    prNumber: 10,
+    token: "t",
+    listComments: async () => [
+      {
+        body: SAMPLE_COMMENT,
+        created_at: "2026-05-29T10:00:00Z",
+        html_url: "https://example.com/c/1",
+      },
+    ],
+    listRuns: async () => [
+      {
+        id: 99,
+        display_title: "fix-ready · dispatch · PR #10 · ready_for_ai_review",
+        created_at: "2026-05-29T10:00:05Z",
+        status: "completed",
+        conclusion: "success",
+        html_url: "https://example.com/run/99",
+      },
+    ],
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.dispatch_run_id, 99);
+});

--- a/.github/scripts/slack-notify.cjs
+++ b/.github/scripts/slack-notify.cjs
@@ -4,6 +4,9 @@ const MARKER_PREFIX = "slack-thread:v1";
 const SLACK_POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage";
 const AI_REVIEW_HEADING_1 = "## 1. レビュー結果";
 const AI_REVIEW_HEADING_22 = "## 22. Status更新意図";
+const FIX_COMPLETE_TITLE = "# Fix Review Comments Result";
+const FIX_COMPLETE_HEADING_1 = "## 1. 対応結果";
+const FIX_COMPLETE_HEADING_12 = "## 12. Status更新意図";
 const AUTOMATION_STATUS_COMMENT_PREFIX = "Project Status更新意図:";
 const SLACK_THREAD_MARKER_NOTE = "Slack thread marker for GitHub Actions automation.";
 const KNOWN_REVIEW_RESULTS = [
@@ -11,6 +14,13 @@ const KNOWN_REVIEW_RESULTS = [
   "request_changes",
   "needs_human_decision",
   "split_required",
+  "blocked",
+];
+const KNOWN_FIX_OUTCOMES = [
+  "ready_for_ai_review",
+  "needs_human_decision",
+  "split_required",
+  "partial_fix",
   "blocked",
 ];
 
@@ -258,6 +268,19 @@ function normalizeKnownReviewToken(value) {
   return "";
 }
 
+function normalizeKnownFixOutcome(value) {
+  const text = String(value || "").trim();
+  if (!text) return "";
+  const lowered = text.toLowerCase().replace(/\s+/g, "_");
+  for (const item of KNOWN_FIX_OUTCOMES) {
+    if (lowered === item) return item;
+  }
+  if (text.includes("再AI Review可能")) return "ready_for_ai_review";
+  if (text.includes("Human判断待ち")) return "needs_human_decision";
+  if (text.includes("別Issue化")) return "split_required";
+  return "";
+}
+
 function normalizeReviewResult(value) {
   const direct = normalizeKnownReviewToken(value);
   if (direct) return direct;
@@ -344,6 +367,55 @@ function expectedCurrentStatusForHumanReview() {
   return "Human Review";
 }
 
+function hasFixCompleteResultHeading(body) {
+  const text = String(body || "");
+  return text.includes(FIX_COMPLETE_HEADING_1) || text.includes(FIX_COMPLETE_TITLE);
+}
+
+function hasFixOutcomeTableRow(body) {
+  return /\|\s*Fix Outcome\s*\|/i.test(String(body || ""));
+}
+
+function extractFixOutcomeTableCell(body) {
+  const text = String(body || "");
+  const backtick = /\|\s*Fix Outcome\s*\|\s*`([^`]+)`\s*\|/i.exec(text);
+  if (backtick) return normalizeKnownFixOutcome(backtick[1]);
+  const plain = /\|\s*Fix Outcome\s*\|\s*([^\n|]+?)\s*\|/i.exec(text);
+  if (plain) return normalizeKnownFixOutcome(plain[1]);
+  return "";
+}
+
+function isFixCompleteResultComment(body) {
+  if (isAutomationBypassComment(body)) return false;
+  const text = String(body || "");
+  if (hasFixCompleteResultHeading(text)) return true;
+  if (!hasFixOutcomeTableRow(text)) return false;
+  return Boolean(extractFixOutcomeTableCell(text));
+}
+
+function extractFixOutcomeFromComment(body) {
+  if (!isFixCompleteResultComment(body)) {
+    return { ok: false, reason: "not_fix_complete_comment" };
+  }
+  const outcome = extractFixOutcomeTableCell(body);
+  if (!outcome) return { ok: false, reason: "fix_outcome_not_found" };
+  return { ok: true, value: outcome };
+}
+
+function expectedCurrentStatusForFixComplete() {
+  return "In Progress";
+}
+
+function fixOutcomeLabelForHumans(fixOutcome) {
+  const normalized = normalizeKnownFixOutcome(fixOutcome);
+  if (normalized === "ready_for_ai_review") return "再AI Review可能";
+  if (normalized === "needs_human_decision") return "Human判断待ち";
+  if (normalized === "split_required") return "別Issue化が必要";
+  if (normalized === "partial_fix") return "一部対応・再レビュー不可";
+  if (normalized === "blocked") return "blocked";
+  return normalized || "不明";
+}
+
 function buildStatusSyncConfirmationComment({ taskIssueNumber, nextStatus }) {
   return `Project Status更新意図: Issue #${taskIssueNumber} を \`${nextStatus}\` へ更新しました。`;
 }
@@ -382,8 +454,12 @@ module.exports = {
   MARKER_PREFIX,
   AI_REVIEW_HEADING_1,
   AI_REVIEW_HEADING_22,
+  FIX_COMPLETE_TITLE,
+  FIX_COMPLETE_HEADING_1,
+  FIX_COMPLETE_HEADING_12,
   AUTOMATION_STATUS_COMMENT_PREFIX,
   KNOWN_REVIEW_RESULTS,
+  KNOWN_FIX_OUTCOMES,
   buildSlackText,
   buildThreadKey,
   buildThreadMarker,
@@ -395,6 +471,7 @@ module.exports = {
   postSlackMessage,
   relatedIssueNumber,
   normalizeKnownReviewToken,
+  normalizeKnownFixOutcome,
   normalizeReviewResult,
   isAutomationBypassComment,
   isAiReviewResultComment,
@@ -402,6 +479,11 @@ module.exports = {
   statusNamesEqual,
   expectedCurrentStatusForAiReview,
   expectedCurrentStatusForHumanReview,
+  hasFixCompleteResultHeading,
+  isFixCompleteResultComment,
+  extractFixOutcomeFromComment,
+  expectedCurrentStatusForFixComplete,
+  fixOutcomeLabelForHumans,
   buildStatusSyncConfirmationComment,
   reviewResultLabelForHumans,
   statusFromReviewResult,

--- a/.github/scripts/slack-notify.test.cjs
+++ b/.github/scripts/slack-notify.test.cjs
@@ -227,3 +227,33 @@ test("upsertThreadMarkerComment: 既存markerがあれば更新する", async ()
   assert.match(calls[0][1].body, /ts=2.000/);
 });
 
+const SAMPLE_FIX_COMPLETE = `# Fix Review Comments Result
+
+## 1. 対応結果
+
+| 項目 | 内容 |
+| ---- | ---- |
+| Fix Outcome | \`ready_for_ai_review\` |
+| 対象PR | \`#10\` |
+
+## 12. Status更新意図
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 次Status | \`AI Review\` |
+`;
+
+test("isFixCompleteResultComment: fix-complete形式を識別する", () => {
+  assert.equal(slack.isFixCompleteResultComment(SAMPLE_FIX_COMPLETE), true);
+  assert.equal(slack.extractFixOutcomeFromComment(SAMPLE_FIX_COMPLETE).value, "ready_for_ai_review");
+});
+
+test("extractFixOutcomeFromComment: split_requiredはdispatch対象外", () => {
+  const body = SAMPLE_FIX_COMPLETE.replace("ready_for_ai_review", "split_required");
+  assert.equal(slack.extractFixOutcomeFromComment(body).value, "split_required");
+});
+
+test("expectedCurrentStatusForFixComplete: In Progressを前提とする", () => {
+  assert.equal(slack.expectedCurrentStatusForFixComplete(), "In Progress");
+});
+

--- a/.github/scripts/verify-fix-complete-dispatch.sh
+++ b/.github/scripts/verify-fix-complete-dispatch.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+echo "== 1. Unit tests =="
+node --test \
+  .github/scripts/slack-notify.test.cjs \
+  .github/scripts/dispatch-pr-ready-for-ai-review.test.cjs \
+  .github/scripts/publish-fix-complete-and-dispatch.test.cjs
+
+echo ""
+echo "== 2. Template parse (fix-complete-comment.md) =="
+node - <<'NODE'
+const fs = require("fs");
+const slack = require("./.github/scripts/slack-notify.cjs");
+const template = fs.readFileSync("prompts/templates/review/fix-complete-comment.md", "utf8");
+const sample = template
+  .replace(/#<PR番号>/g, "#9999")
+  .replace(/#<Issue番号>/g, "#265")
+  .replace(/<branch名>/g, "test/verify")
+  .replace(/@<review-definition>/g, "@prompts/definitions/_examples/review-definition.example.yaml")
+  .replace(/#<PR番号>/g, "#9999");
+if (!slack.isFixCompleteResultComment(sample)) {
+  throw new Error("Template is not recognized as fix-complete comment");
+}
+const extracted = slack.extractFixOutcomeFromComment(sample);
+if (!extracted.ok || extracted.value !== "ready_for_ai_review") {
+  throw new Error(`Unexpected Fix Outcome: ${JSON.stringify(extracted)}`);
+}
+console.log("OK: template -> ready_for_ai_review");
+NODE
+
+echo ""
+echo "== 3. dry-run: ready_for_ai_review (comment + dispatch) =="
+COMMENT_FILE="$ROOT/.tmp-fix-complete-comment-verify.md"
+if [[ ! -f "$COMMENT_FILE" ]]; then
+  echo "WARN: $COMMENT_FILE missing; using inline sample"
+  COMMENT_FILE=""
+fi
+export GH_TOKEN="${GH_TOKEN:-dry-run-test}"
+if [[ -n "$COMMENT_FILE" ]]; then
+  node .github/scripts/publish-fix-complete-and-dispatch.cjs \
+    --repository ryo-chan-k6/GiftRecommendAPP_MVP_CYCLE_3 \
+    --pr 9999 \
+    --comment-file "$COMMENT_FILE" \
+    --dry-run | node -e "const j=JSON.parse(require('fs').readFileSync(0,'utf8')); if(!j.ok||j.dispatch_skipped||j.fix_outcome!=='ready_for_ai_review'){process.exit(1)} console.log('OK: dispatch planned for', j.fix_outcome);"
+else
+  echo "SKIP file-based dry-run"
+fi
+
+echo ""
+echo "== 4. dry-run: split_required (dispatch skipped) =="
+node - <<'NODE'
+const fs = require("fs");
+const publish = require("./.github/scripts/publish-fix-complete-and-dispatch.cjs");
+const body = fs.readFileSync(".tmp-fix-complete-comment-verify.md", "utf8").replace(/ready_for_ai_review/g, "split_required");
+publish.publishFixCompleteAndDispatch({
+  repository: "ryo-chan-k6/GiftRecommendAPP_MVP_CYCLE_3",
+  prNumber: 9999,
+  commentBody: body,
+  token: "dry-run-test",
+  dryRun: true,
+}).then((result) => {
+  if (!result.ok || !result.dispatch_skipped || result.fix_outcome !== "split_required") {
+    console.error(JSON.stringify(result, null, 2));
+    process.exit(1);
+  }
+  console.log("OK: split_required skipped dispatch");
+});
+NODE
+
+echo ""
+echo "== 5. Workflow file exists =="
+test -f .github/workflows/pr-ready-for-ai-review.yml
+grep -q "fix_ready_for_ai_review" .github/workflows/pr-ready-for-ai-review.yml
+grep -q "expectedCurrentStatusForFixComplete" .github/workflows/pr-ready-for-ai-review.yml
+echo "OK: workflow triggers and status guard present"
+
+echo ""
+echo "== 6. Remote workflow registration (optional) =="
+if command -v gh >/dev/null 2>&1; then
+  if gh workflow list --repo ryo-chan-k6/GiftRecommendAPP_MVP_CYCLE_3 2>/dev/null | grep -qi "ready for ai review"; then
+    echo "OK: workflow registered on GitHub remote"
+  else
+    echo "SKIP: workflow not yet on remote (merge/push required for live E2E)"
+  fi
+else
+  echo "SKIP: gh not available"
+fi
+
+echo ""
+echo "ALL LOCAL VERIFICATION PASSED"

--- a/.github/workflows/pr-ready-for-ai-review.yml
+++ b/.github/workflows/pr-ready-for-ai-review.yml
@@ -1,0 +1,304 @@
+name: PR Ready For AI Review Status Sync
+
+run-name: "fix-ready · ${{ github.event_name == 'repository_dispatch' && 'dispatch' || 'manual' }} · PR #${{ github.event.client_payload.pr_number || github.event.inputs.pr_number }} · ${{ github.event.client_payload.fix_outcome || github.event.inputs.fix_outcome || 'ready_for_ai_review' }}"
+
+on:
+  repository_dispatch:
+    types:
+      - fix_ready_for_ai_review
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 対象PR番号
+        required: true
+      fix_outcome:
+        description: Fix Outcome（ready_for_ai_review のみ Status 更新）
+        required: false
+        default: "ready_for_ai_review"
+      dry_run:
+        description: trueの場合は更新せずログのみ出力する
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: pr-ready-for-ai-review-${{ github.event.client_payload.pr_number || github.event.inputs.pr_number }}
+  cancel-in-progress: false
+
+jobs:
+  sync-status-and-notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Update Project Status and notify Slack
+        uses: actions/github-script@v8
+        env:
+          PROJECT_OWNER: ${{ vars.PROJECT_OWNER }}
+          PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID_DEVOPS: ${{ vars.SLACK_CHANNEL_ID_DEVOPS }}
+        with:
+          github-token: ${{ secrets.PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const path = require("path");
+            const slack = require(path.join(process.env.GITHUB_WORKSPACE, ".github/scripts/slack-notify.cjs"));
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const repositoryFullName = `${owner}/${repo}`;
+            const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+            const projectOwner = process.env.PROJECT_OWNER || owner;
+            const projectNumber = Number(process.env.PROJECT_NUMBER || "4");
+            const dryRun =
+              context.eventName === "workflow_dispatch" &&
+              String(context.payload.inputs?.dry_run || "") === "true";
+
+            function skipWithSummary(reason, details = {}) {
+              core.info(`Skipped: ${reason}`);
+              const lines = [`Skipped: ${reason}`];
+              for (const [key, value] of Object.entries(details)) {
+                if (value !== undefined && value !== "") lines.push(`${key}: ${value}`);
+              }
+              return core.summary.addRaw(lines.join("\n") + "\n").write();
+            }
+
+            async function loadProject() {
+              const query = `
+                query($owner: String!, $number: Int!) {
+                  user(login: $owner) {
+                    projectV2(number: $number) {
+                      id
+                      fields(first: 100) {
+                        nodes {
+                          ... on ProjectV2SingleSelectField {
+                            id
+                            name
+                            options { id name }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`;
+              const data = await github.graphql(query, { owner: projectOwner, number: projectNumber });
+              return data.user?.projectV2 || null;
+            }
+
+            async function issueNodeId(issueNumber) {
+              const query = `
+                query($owner: String!, $repo: String!, $number: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    issue(number: $number) { id }
+                  }
+                }`;
+              const data = await github.graphql(query, { owner, repo, number: issueNumber });
+              return data.repository?.issue?.id || null;
+            }
+
+            async function findProjectItem(issueId) {
+              const query = `
+                query($owner: String!, $number: Int!, $after: String) {
+                  user(login: $owner) {
+                    projectV2(number: $number) {
+                      items(first: 100, after: $after) {
+                        nodes {
+                          id
+                          content { ... on Issue { id } }
+                        }
+                        pageInfo { hasNextPage endCursor }
+                      }
+                    }
+                  }
+                }`;
+              let after = null;
+              for (;;) {
+                const data = await github.graphql(query, { owner: projectOwner, number: projectNumber, after });
+                const items = data.user?.projectV2?.items;
+                const hit = items?.nodes?.find((item) => item.content?.id === issueId);
+                if (hit) return hit.id;
+                if (!items?.pageInfo?.hasNextPage) return null;
+                after = items.pageInfo.endCursor;
+              }
+            }
+
+            async function readProjectItemStatus(itemId) {
+              const query = `
+                query($itemId: ID!) {
+                  node(id: $itemId) {
+                    ... on ProjectV2Item {
+                      fieldValueByName(name: "Status") {
+                        ... on ProjectV2ItemFieldSingleSelectValue { name }
+                      }
+                    }
+                  }
+                }`;
+              const data = await github.graphql(query, { itemId });
+              return data.node?.fieldValueByName?.name || "";
+            }
+
+            async function updateStatus(project, itemId, statusName) {
+              const field = project.fields.nodes.find((candidate) => candidate.name === "Status");
+              const option = field?.options?.find((candidate) => candidate.name === statusName);
+              if (!field || !option) throw new Error(`Project Status option not found: ${statusName}`);
+              const mutation = `
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId,
+                    itemId: $itemId,
+                    fieldId: $fieldId,
+                    value: { singleSelectOptionId: $optionId }
+                  }) { projectV2Item { id } }
+                }`;
+              if (dryRun) {
+                core.info(`[dry_run] update status: ${statusName}`);
+                return;
+              }
+              await github.graphql(mutation, {
+                projectId: project.id,
+                itemId,
+                fieldId: field.id,
+                optionId: option.id,
+              });
+            }
+
+            let prNumber;
+            let fixOutcome = "ready_for_ai_review";
+
+            if (context.eventName === "workflow_dispatch") {
+              prNumber = Number(context.payload.inputs.pr_number);
+              fixOutcome = slack.normalizeKnownFixOutcome(context.payload.inputs.fix_outcome || "") || "ready_for_ai_review";
+            } else if (context.eventName === "repository_dispatch") {
+              const payload = context.payload.client_payload || {};
+              prNumber = Number(payload.pr_number);
+              fixOutcome = slack.normalizeKnownFixOutcome(payload.fix_outcome || "") || "ready_for_ai_review";
+            } else {
+              core.setFailed(`Unsupported event: ${context.eventName}`);
+              return;
+            }
+
+            if (fixOutcome !== "ready_for_ai_review") {
+              return skipWithSummary("fix_outcome_not_ready_for_ai_review", {
+                PR: `#${prNumber}`,
+                "Fix Outcome": fixOutcome,
+              });
+            }
+
+            if (!prNumber) {
+              core.setFailed("PR number is missing.");
+              return;
+            }
+
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            if (pr.head?.repo?.full_name !== repositoryFullName) {
+              core.info("PR from fork is out of scope; skipped.");
+              return;
+            }
+
+            const issueNumber = slack.relatedIssueNumber(pr.body || "");
+            if (!issueNumber) {
+              core.setFailed("PR本文から対象Issueを解決できませんでした。`Related to #<Task Issue番号>` または `Closes #<Epic Issue番号>` を記載してください。");
+              return;
+            }
+
+            const project = await loadProject();
+            if (!project) {
+              core.setFailed("ProjectV2を解決できませんでした。");
+              return;
+            }
+            const id = await issueNodeId(issueNumber);
+            if (!id) {
+              core.setFailed(`Issue #${issueNumber} のNode IDを解決できませんでした。`);
+              return;
+            }
+            const itemId = await findProjectItem(id);
+            if (!itemId) {
+              core.setFailed(`Issue #${issueNumber} のProject itemを解決できませんでした。`);
+              return;
+            }
+
+            const currentStatus = await readProjectItemStatus(itemId);
+            const expectedCurrent = slack.expectedCurrentStatusForFixComplete();
+            const nextStatus = "AI Review";
+
+            if (expectedCurrent && currentStatus && !slack.statusNamesEqual(currentStatus, expectedCurrent)) {
+              if (slack.statusNamesEqual(currentStatus, nextStatus)) {
+                return skipWithSummary("already_at_next_status", {
+                  PR: `#${prNumber}`,
+                  Issue: `#${issueNumber}`,
+                  Status: currentStatus,
+                });
+              }
+              return skipWithSummary("current_status_mismatch", {
+                PR: `#${prNumber}`,
+                Issue: `#${issueNumber}`,
+                "Current Status": currentStatus,
+                "Expected Status": expectedCurrent,
+                "Next Status": nextStatus,
+              });
+            }
+
+            if (currentStatus && slack.statusNamesEqual(currentStatus, nextStatus)) {
+              return skipWithSummary("already_at_next_status", {
+                PR: `#${prNumber}`,
+                Issue: `#${issueNumber}`,
+                Status: currentStatus,
+              });
+            }
+
+            await updateStatus(project, itemId, nextStatus);
+
+            const channel = process.env.SLACK_CHANNEL_ID_DEVOPS || "";
+            const threadKey = slack.buildThreadKey({ owner, repo, kind: "pr", number: prNumber });
+            const comments = await slack.listIssueComments({ github, owner, repo, issueNumber: prNumber });
+            const threadTs = slack.findThreadTsFromComments(comments, threadKey, channel);
+            const text = slack.buildSlackText({
+              level: "info",
+              title: "再AI Review可能",
+              summary: pr.title,
+              fields: {
+                PR: `#${prNumber}`,
+                Issue: `#${issueNumber}`,
+                Branch: pr.head.ref,
+                Target: pr.base.ref,
+                "Fix Outcome": slack.fixOutcomeLabelForHumans(fixOutcome),
+                "Next Status": nextStatus,
+              },
+              links: {
+                PR: pr.html_url,
+                Issue: `${serverUrl}/${repositoryFullName}/issues/${issueNumber}`,
+              },
+              humanAction: "/review-pr を実行してください。",
+            });
+            const result = await slack.postSlackMessage({
+              token: process.env.SLACK_BOT_TOKEN,
+              channel,
+              text,
+              threadTs,
+              dryRun,
+            });
+
+            if (!dryRun) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: prNumber,
+                body: slack.buildStatusSyncConfirmationComment({
+                  taskIssueNumber: issueNumber,
+                  nextStatus,
+                }),
+              });
+            }
+
+            await core.summary
+              .addHeading("Fix完了後 Status / Slack通知")
+              .addRaw(`PR: #${prNumber}\n\nIssue: #${issueNumber}\n\nStatus: \`${nextStatus}\`\n\nSlack: ${result.ok ? "ok" : "failed"}\n`)
+              .addRaw(result.error ? `\nSlack error: \`${result.error}\`\n` : "")
+              .write();
+            if (!result.ok) {
+              core.warning(`Slack notification failed: ${result.error || "unknown"}`);
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,8 @@ Human Review
 
 どちらの運用でも、Human Reviewと人間によるmerge判断を省略してはならない。
 
+**Machine account:** AI Agent の commit / push / PR 作成は `okuri-ai-bot`（Classic PAT）で行い、Human Review / merge は `ryo-chan-k6` が行う。詳細は [AI機械アカウント運用設計書](docs/00_共通/AIエージェント運用/AI機械アカウント運用設計書.md) および `.github/ai-bot-account.json`。
+
 ---
 
 ## 12. GitHub運用方針
@@ -1125,6 +1127,7 @@ PR作成前に、以下を確認する。
 [ ] PR本文に影響範囲が記載されている
 [ ] PR本文にHuman Review観点が記載されている
 [ ] AI Reviewを実行できる状態である
+[ ] PR author が machine account（`.github/ai-bot-account.json`）である
 ```
 
 ---

--- a/ai-logs/experiments/2026-05-29-fix-ready-status-sync-e2e.md
+++ b/ai-logs/experiments/2026-05-29-fix-ready-status-sync-e2e.md
@@ -1,0 +1,26 @@
+# fix 完了時 Status 同期 E2E
+
+## 目的
+
+`/fix-review-comments` 完了時の `publish-fix-complete-and-dispatch.cjs` と `pr-ready-for-ai-review.yml` の live 検証。
+
+## 手順
+
+1. `feat/fix-complete-status-dispatch` を develop へ PR / merge（または feature branch で workflow_dispatch）
+2. bot PAT で検証用 PR を open（author = `okuri-ai-bot`）
+3. 対象 Task Issue の Projects Status を `In Progress` にする
+4. `publish-fix-complete-and-dispatch.cjs` を実行
+5. Actions `fix-ready · dispatch · PR #n` 成功、Status = `AI Review` を確認
+
+## 記録
+
+| 項目 | 値 |
+|------|-----|
+| 検証 PR | （記入） |
+| Task Issue | （記入） |
+| dispatch run | （記入） |
+| Status 遷移 | （記入） |
+
+## 後片付け
+
+検証 PR は Close 可（merge 不要）。

--- a/ai-logs/experiments/2026-05-30-bot-author-human-review-e2e.md
+++ b/ai-logs/experiments/2026-05-30-bot-author-human-review-e2e.md
@@ -1,0 +1,28 @@
+# bot author Human Review E2E
+
+## 目的
+
+`okuri-ai-bot`（machine account）の Classic PAT で PR を open し、`ryo-chan-k6` が Human Review（Approve / Request changes）できることを確認する。
+
+正本設定: `.github/ai-bot-account.json`
+
+## 手順
+
+1. bot PAT（`GH_BOT_TOKEN`）で branch push
+2. `gh pr create`（author = `okuri-ai-bot`）
+3. `ryo-chan-k6` で PR を開き Review changes → Approve / Request changes が選べること
+
+## 再実行
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+bash .github/scripts/e2e-bot-author-test-pr.sh
+```
+
+## 後片付け
+
+検証後、この PR は Close してよい（merge 不要）。
+
+## 関連
+
+- [AI機械アカウント運用設計書](../../docs/00_共通/AIエージェント運用/AI機械アカウント運用設計書.md)

--- a/docs/00_共通/AIエージェント運用/AIエージェント活用型_開発運用フロー設計書.md
+++ b/docs/00_共通/AIエージェント運用/AIエージェント活用型_開発運用フロー設計書.md
@@ -607,6 +607,10 @@ AIレビュー完了時の Projects Status 更新は [PRレビュー完了時Sta
 
 人間レビューは、最終品質判断として実施する。
 
+**実施者:** `ryo-chan-k6`（Personal account）。PR author（machine account `okuri-ai-bot`）とは別アカウントとする（[AI機械アカウント運用設計書](./AI機械アカウント運用設計書.md)）。
+
+**GitHub 操作:** Human Review 指摘は PR Review の **Request changes** で行う（Conversation コメントのみでは Status 連動しない）。
+
 人間レビューでは、主に以下を確認する。
 
 - 方針として妥当か

--- a/docs/00_共通/AIエージェント運用/AIエージェント活用型_開発運用フロー設計書.md
+++ b/docs/00_共通/AIエージェント運用/AIエージェント活用型_開発運用フロー設計書.md
@@ -677,7 +677,7 @@ AIに修正作業を開始させるには、明示的な作業着手トリガー
 4. Fixer AIがPRコメント・Issue本文・Definitionを読み込む
 5. 同一Branchで修正する
 6. commitしてPRを更新する
-7. Projects Statusを AI Review へ戻す
+7. Projects Statusを AI Review へ戻す（`ready_for_ai_review` 時は `publish-fix-complete-and-dispatch.cjs`）
 ```
 
 ---

--- a/docs/00_共通/AIエージェント運用/AI機械アカウント運用設計書.md
+++ b/docs/00_共通/AIエージェント運用/AI機械アカウント運用設計書.md
@@ -1,0 +1,98 @@
+# AI機械アカウント（Machine Account）運用設計書
+
+## 1. 目的
+
+MVP Cycle 3 の AI 主導開発において、**Human Review**（GitHub PR Review の Approve / Request changes）を人間（`ryo-chan-k6`）が実施できるよう、GitHub 上の **PR author** と **Human Reviewer** を分離する。
+
+GitHub は PR author 自身に Approve / Request changes を許可しない。AI Agent が人間アカウントの `gh` 認証で PR を open すると author が人間になり、Human Review 正式経路（`changes_requested` → Projects `In Progress`）が使えない。
+
+本書は machine account（`okuri-ai-bot`）と Classic PAT による運用を定義する。
+
+---
+
+## 2. 正本・設定ファイル
+
+| 項目 | 正本 |
+| ---- | ---- |
+| アカウント定義 | `.github/ai-bot-account.json` |
+| 認証検証 CLI | `.github/scripts/gh-bot-auth.cjs` |
+| PAT 設定例 | `.github/gh-bot.env.example` |
+| Cursor Rule | `.cursor/rules/github-operation.mdc` §3.16 |
+| Human Review 経路 | [PRレビュー完了時Status更新ワークフロー仕様書](../../06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md) §5.2 |
+
+---
+
+## 3. アカウント役割
+
+| アカウント | 種別 | 役割 |
+| ---------- | ---- | ---- |
+| `okuri-ai-bot` | Machine account | commit / push / Issue 作成 / PR open / AI Review dispatch |
+| `ryo-chan-k6` | Personal account | Human Review（Approve / Request changes）、merge、リポジトリ管理 |
+
+Organization 移行は MVP Cycle 3 では行わない。bot は **Collaborator（Write）** として個人リポジトリに参加する。
+
+---
+
+## 4. PAT
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 発行主体 | **machine account**（`okuri-ai-bot`）。人間アカウントの PAT ではない |
+| 種別 | **Classic PAT**（`repo` scope）。Collaborator の private repo では Fine-grained PAT で対象 repo を選べない |
+| 保管 | `~/.config/gift-recommend/gh-bot.env`（`chmod 600`）。リポジトリに commit しない |
+| 環境変数 | `GH_BOT_TOKEN` |
+
+---
+
+## 5. AI Agent 作業前の必須手順
+
+GitHub へ **書き込む** 操作（commit / push / `gh issue create` / `gh pr create` / `publish-ai-review-and-dispatch.cjs`）の前:
+
+```bash
+node .github/scripts/gh-bot-auth.cjs verify
+eval "$(node .github/scripts/gh-bot-auth.cjs print-setup)"
+```
+
+`verify` が `OK: authenticated as okuri-ai-bot` を返すこと。
+
+commit author は bot 名義に揃える（`print-git-user` の JSON を `git -c user.name=... -c user.email=...` に利用）。
+
+---
+
+## 6. Human Review
+
+| 操作 | 実施者 | 備考 |
+| ---- | ------ | ---- |
+| PR Review → Approve | `ryo-chan-k6` | bot 認証を **解除**（`unset GH_TOKEN` または人間用 gh セッション） |
+| PR Review → Request changes | `ryo-chan-k6` | コメントのみでは Status 連動しない。正式 PR Review 必須 |
+| merge | `ryo-chan-k6` | AI Agent は merge しない |
+
+---
+
+## 7. 禁止事項
+
+- 人間 PAT で AI 作業用 PR を open すること（author が人間になり Human Review 不可）
+- `GH_BOT_TOKEN` を Issue / PR / docs / リポジトリに記載すること
+- machine account で Human Review（Approve / Request changes）すること
+- machine account で merge すること
+
+---
+
+## 8. E2E 検証
+
+検証手順の記録: [ai-logs/experiments/2026-05-30-bot-author-human-review-e2e.md](../../../ai-logs/experiments/2026-05-30-bot-author-human-review-e2e.md)
+
+再実行スクリプト:
+
+```bash
+bash .github/scripts/e2e-bot-author-test-pr.sh
+```
+
+---
+
+## 9. 関連ドキュメント
+
+- [AIエージェント活用型 開発運用フロー設計書](./AIエージェント活用型_開発運用フロー設計書.md) §22
+- [AIレビュー運用設計書](./AIレビュー運用設計書.md)
+- [Commands設計書](./Commands設計書.md) §17 / §18
+- [Projects運用ルール](../プロジェクト管理/Projects運用ルール.md) §17.6

--- a/docs/00_共通/AIエージェント運用/Commands設計書.md
+++ b/docs/00_共通/AIエージェント運用/Commands設計書.md
@@ -253,20 +253,20 @@ Commandは、GitHub ProjectsのStatus遷移と連動する。
 
 Statusの正本はGitHub Projectsとする。
 
-| Command                 | 主なStatus影響                                    |
-| ----------------------- | ------------------------------------------------- |
-| `/start-epic`           | `Todo` → `In Progress`                            |
-| `/start-task`           | `Todo` → `In Progress`                            |
-| `/work-issue`           | `Todo` または `In Progress` → `In Progress`       |
-| `/create-pr`            | `In Progress` → `AI Review`                       |
-| `/review-pr`            | `AI Review` → `Human Review` または `In Progress` |
-| `/fix-review-comments`  | `In Progress` → `AI Review`                       |
-| `/create-contract-task` | 新規Issue作成後、原則 `Todo` → `In Progress`      |
-| `/summarize-work`       | 原則Status変更なし                                |
+| Command                 | 主なStatus影響                                    | 正本 CLI / トリガー |
+| ----------------------- | ------------------------------------------------- | ------------------- |
+| `/start-epic`           | `Todo` → `In Progress`                            | Branch 作成 workflow |
+| `/start-task`           | `Todo` → `In Progress`                            | Branch 作成 workflow |
+| `/work-issue`           | `Todo` または `In Progress` → `In Progress`       | — |
+| `/create-pr`            | `In Progress` → `AI Review`                       | PR open workflow |
+| `/review-pr`            | `AI Review` → `Human Review` または `In Progress` | `publish-ai-review-and-dispatch.cjs` |
+| `/fix-review-comments`  | `In Progress` → `AI Review`（完了時）             | `publish-fix-complete-and-dispatch.cjs` |
+| `/create-contract-task` | 新規Issue作成後、原則 `Todo` → `In Progress`      | Branch 作成 workflow |
+| `/summarize-work`       | 原則Status変更なし                                | — |
 
 Status更新は、Command実行結果に基づいてGitHub ActionsまたはGitHub運用スクリプトが実施する。
 
-Commandは、Status更新の意図を明確に出力する。
+Commandは、Status更新の意図を明確に出力する（Fix Outcome / Review Result）。
 
 ### 11.1 Issue close / Done制御
 
@@ -869,7 +869,7 @@ PR番号を併記してもよい。
 9. commitを追加する
 10. PR本文またはPRコメントを更新する
 11. 修正サマリを記録する
-12. Statusを AI Review へ戻す判断材料を出す
+12. Statusを AI Review へ戻す（Fix Outcome に応じ §18.10）
 13. 必要に応じてSlack通知を作成する
 
 ```
@@ -911,6 +911,23 @@ PR番号を併記してもよい。
 - 親Epic Branchとの最新化で競合が発生している
 - 後続Taskへの影響が大きい
 - 人間判断なしに進めると危険である
+
+### 18.10 Status 同期（dispatch 忘れ防止）
+
+Fix 完了後（Fix Outcome = `ready_for_ai_review`）の Projects Status 更新は [PR再AI Review待ちStatus更新ワークフロー](../../06_実装設計/github_actions/PR再AI%20Review待ちStatus更新ワークフロー仕様書.md) が担う。`/fix-review-comments` は **コメント投稿と dispatch を分離しない**。
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 正本 CLI | `.github/scripts/publish-fix-complete-and-dispatch.cjs` |
+| PR コメント正本 | `prompts/templates/review/fix-complete-comment.md` |
+| 推奨 | `--comment-file` で fix-complete-comment 形式を渡し、コメント + dispatch を 1 回実行 |
+| 完了確認 | 同一 CLI の `--verify` |
+| recovery | `--dispatch-only`（コメント投稿済み時）または `workflow_dispatch`（PR Ready For AI Review Status Sync） |
+| Machine account | dispatch / PR コメント投稿前に `GH_BOT_TOKEN` で bot 認証 |
+
+`split_required` / `partial_fix` / `blocked` 等では dispatch **しない**（Status は `In Progress` 維持）。
+
+詳細手順は `.cursor/commands/fix-review-comments.md` §12.5 を正本とする。
 
 ---
 

--- a/docs/00_共通/AIエージェント運用/Commands設計書.md
+++ b/docs/00_共通/AIエージェント運用/Commands設計書.md
@@ -595,6 +595,7 @@ PRはレビュー正本であり、作業結果、確認結果、AIレビュー�
 ### 16.5 処理
 
 ````
+0. machine account 認証を確認する（`gh-bot-auth.cjs verify` + `print-setup`）。PR author が bot であること
 1. 対象Issueを確認する
 2. 作業Branchを確認する
 3. Task Branchが親Epic Branchの最新状態を取り込んでいるか確認する
@@ -707,6 +708,7 @@ PR番号を併記してもよい。
 ### 17.5 処理
 
 ```text
+0. machine account 認証を確認する（`gh-bot-auth.cjs`）
 1. PRを確認する
 2. 対象Issueを確認する
 3. Task Definitionを確認する
@@ -795,6 +797,7 @@ AI Review 完了後の Projects Status 更新は [PR Review Status Sync](../../0
 | 完了確認 | 同一 CLI の `--verify` |
 | recovery | `--dispatch-only`（コメント投稿済み時） |
 | Harness | `review-pr` + `live-run` 完了後、post-run 検証で dispatch 忘れを **ジョブ失敗** |
+| Machine account | dispatch / PR コメント投稿前に `GH_BOT_TOKEN` で bot 認証（[AI機械アカウント運用設計書](./AI機械アカウント運用設計書.md)） |
 
 詳細手順は `.cursor/commands/review-pr.md` §15.5 を正本とする。
 

--- a/docs/00_共通/AIエージェント運用/README.md
+++ b/docs/00_共通/AIエージェント運用/README.md
@@ -76,6 +76,7 @@ Slackは通知・サマリ用途であり、作業計画や成果物の正本に
 | `Task Definition設計書.md`                     | AIへの個別作業依頼条件の構造を定義する                      |
 | `Prompts運用ルール.md`                         | `prompts/` 配下の管理・命名・利用ルールを定義する           |
 | `AIレビュー運用設計書.md`                      | AI Reviewの観点、出力、PR反映方針を定義する                 |
+| `AI機械アカウント運用設計書.md`                | machine account / PAT / Human Review 分離を定義する         |
 | `AIログ運用ルール.md`                          | `ai-logs/` の記録対象、粒度、命名規則を定義する             |
 | `Slack通知運用設計書.md`                       | Slack通知タイミング、通知内容、通知先を定義する             |
 | `worktree運用ルール.md`                        | AI並列作業時のworktree配置・削除・競合回避を定義する        |

--- a/docs/00_共通/ディレクトリ構成/プロジェクトディレクトリ構成定義書.md
+++ b/docs/00_共通/ディレクトリ構成/プロジェクトディレクトリ構成定義書.md
@@ -1019,6 +1019,8 @@ ai-logs/cross-cutting/
 
 ```text
 .github/
+├─ ai-bot-account.json
+├─ gh-bot.env.example
 ├─ ISSUE_TEMPLATE/
 ├─ PULL_REQUEST_TEMPLATE.md
 ├─ PULL_REQUEST_TEMPLATE/
@@ -1028,6 +1030,8 @@ ai-logs/cross-cutting/
 
 | パス                       | 役割                                                       |
 | -------------------------- | ---------------------------------------------------------- |
+| `ai-bot-account.json`      | machine account login / human reviewer の正本設定          |
+| `gh-bot.env.example`       | ローカル PAT 設定ファイル（`~/.config/gift-recommend/`）の例 |
 | `ISSUE_TEMPLATE/`          | GitHub UIで利用するIssueテンプレートを配置する             |
 | `PULL_REQUEST_TEMPLATE.md` | GitHub PRテンプレート選択ガイドを配置する                  |
 | `PULL_REQUEST_TEMPLATE/`   | GitHub UIで利用する種別別PRテンプレートを配置する          |
@@ -1106,6 +1110,8 @@ workflow分類はファイル名prefixで表現する。
 | `projects/`      | GitHub Projects連携に関する補助スクリプトを配置する                  |
 | `notifications/` | Slack通知等の通知文面生成・送信補助スクリプトを配置する              |
 | `utils/`         | GitHub運用スクリプト共通utilityを配置する                            |
+
+machine account 認証 CLI（`gh-bot-auth.cjs`）および E2E 用 `e2e-bot-author-test-pr.sh` も `.github/scripts/` 直下に配置する（[AI機械アカウント運用設計書](../AIエージェント運用/AI機械アカウント運用設計書.md)）。
 
 ---
 

--- a/docs/00_共通/プロジェクト管理/Projects運用ルール.md
+++ b/docs/00_共通/プロジェクト管理/Projects運用ルール.md
@@ -498,7 +498,8 @@ Actual Startが未設定の場合は、同時にActual Startを設定する。
 
 以下の場合、StatusをAI Reviewへ更新する。
 
-- PRが作成された
+- PRが作成された（[PR作成時Status更新ワークフロー](./PR作成時Status更新・Slack通知ワークフロー仕様書.md)）
+- `/fix-review-comments` 完了後、Fix Outcome が `ready_for_ai_review` である（[PR再AI Review待ちStatus更新ワークフロー](./PR再AI%20Review待ちStatus更新ワークフロー仕様書.md)）
 - AIレビュー依頼が開始された
 
 ### 17.4 AI Review → Human Review
@@ -582,6 +583,7 @@ no-branch、Branch、PR に関する禁止事項は [Issue運用ルール](./Iss
 | Issue同期とブランチ作成ワークフロー仕様書             | no-branch制御とBranch作成を定義                             |
 | Planned Startに基づくStatus自動更新ワークフロー仕様書 | BacklogからTodoへの自動更新を定義                           |
 | PR作成時Status更新ワークフロー仕様書                  | PR作成時のAI Review更新を定義                               |
+| PR再AI Review待ちStatus更新ワークフロー仕様書         | fix 完了後の In Progress → AI Review 更新を定義             |
 | PRレビュー完了時Status更新ワークフロー仕様書          | AI/Humanレビュー完了時のStatus更新（双方向）を定義          |
 | PR merge時Status更新ワークフロー仕様書                | Done更新とActual End設定を定義                              |
 

--- a/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
@@ -307,6 +307,7 @@ Definition Run Harness が live-run で Issue を起票した後、以下の既�
 | Issue メタデータ → Project 同期 | `.github/workflows/issue-metadata-project-branch.yml` | Issue 本文に Issue 運用メタデータを正しく埋めて作成のみ |
 | Issue → Branch 作成 | 同上 | Issue 本文 no-branch チェックを正しく設定 |
 | PR 作成時 Status / Slack | `.github/workflows/pr-created-status-and-slack.yml` | PR 作成のみ |
+| fix 完了後 Status / Slack | `.github/workflows/pr-ready-for-ai-review.yml` | **`publish-fix-complete-and-dispatch.cjs` で dispatch**（Fixer 実行） |
 | PR レビュー → Status | `.github/workflows/pr-review-status-sync.yml` | **`publish-ai-review-and-dispatch.cjs` で dispatch**（Agent 実行）。Harness live-run 後は post-verify で dispatch 忘れを検証 |
 | PR merge → Done / Slack | `.github/workflows/pr-merged-done-and-slack.yml` | merge は人間判断（AI 不可） |
 | 手動 Slack 通知 | `.github/workflows/slack-notify-manual.yml` | 必要時に `workflow_dispatch` |

--- a/docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PRレビュー完了時Status更新ワークフロー仕様書.md
@@ -271,6 +271,7 @@ Slack通知に失敗しても、Projects Status の更新は取り消さない�
 - 本ワークフローが **失敗（赤）** した場合は、Summary の PR・失敗理由を確認し、テンプレート・コメント・Issue 参照を修正してから再実行すること
 - `PROJECTS_TOKEN` には対象 Project の読み書きに必要なスコープを付与すること
 - Human Review 指摘は GitHub 上の **Request changes**（`changes_requested`）で行うこと（コメントのみでは本経路は動作しない）
+- AI Agent の PR は **machine account**（`.github/ai-bot-account.json`）が author であること。author が人間の場合、Human Review 正式操作（Approve / Request changes）ができない
 
 ## 11. 関連ドキュメント
 

--- a/docs/06_実装設計/github_actions/PR再AI Review待ちStatus更新ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PR再AI Review待ちStatus更新ワークフロー仕様書.md
@@ -1,0 +1,95 @@
+# PR再AI Review待ち Status 更新・Slack通知ワークフロー
+
+## 1. 目的
+
+`/fix-review-comments` 完了後（Fix Outcome = `ready_for_ai_review`）、対象 Issue の Projects Status を `In Progress` から `AI Review` へ更新し、Slack へ再 AI Review 依頼を通知する。
+
+PR **初回作成時** の Status 更新は [PR作成時Status更新ワークフロー](./PR作成時Status更新・Slack通知ワークフロー仕様書.md)（`pr-created-status-and-slack.yml`）が担当し、本ワークフローは **fix 完了後の再 Review 待ち** のみを担う。
+
+Status の正式値は [Projects運用ルール](../../00_共通/プロジェクト管理/Projects運用ルール.md) を正とする。
+
+## 2. 実装ファイル
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 実装ファイル | `.github/workflows/pr-ready-for-ai-review.yml` |
+| dispatch CLI | `.github/scripts/dispatch-pr-ready-for-ai-review.cjs` |
+| 正本 CLI（コメント + dispatch） | `.github/scripts/publish-fix-complete-and-dispatch.cjs` |
+| PR コメント正本 | [fix-complete-comment.md](../../../prompts/templates/review/fix-complete-comment.md) |
+| 共通 script | `.github/scripts/slack-notify.cjs` |
+| Actions 表示名 | `PR Ready For AI Review Status Sync` |
+| Run 名（一覧） | `fix-ready · dispatch · PR #n · ready_for_ai_review` |
+
+## 3. トリガー
+
+```yaml
+on:
+  repository_dispatch:
+    types:
+      - fix_ready_for_ai_review
+  workflow_dispatch:
+```
+
+| 経路 | 用途 |
+| ---- | ---- |
+| `repository_dispatch` | `/fix-review-comments` 完了時（`publish-fix-complete-and-dispatch.cjs` から 1 回） |
+| `workflow_dispatch` | 手動 recovery・受入確認 |
+
+## 4. client_payload / workflow_dispatch 入力
+
+| フィールド | 必須 | 内容 |
+| ---------- | ---- | ---- |
+| `pr_number` | 必須 | 対象 PR 番号 |
+| `fix_outcome` | 任意 | 既定 `ready_for_ai_review`。それ以外は Status 更新しない（正当スキップ） |
+| `fix_body` | 任意 | dispatch 時の監査用（workflow 本体では未使用可） |
+| `dry_run` | workflow_dispatch のみ | `true` のとき API 更新なし |
+
+## 5. Status 遷移
+
+| 条件 | 現在 Status（前提） | 次 Status |
+| ---- | ------------------- | --------- |
+| `fix_outcome` = `ready_for_ai_review` | `In Progress` | `AI Review` |
+
+### 5.1 スキップ条件（正当スキップ・ジョブ成功）
+
+| 条件 | 挙動 |
+| ---- | ---- |
+| `fix_outcome` ≠ `ready_for_ai_review` | スキップ |
+| 現在 Status が `In Progress` でない（かつ `AI Review` でもない） | スキップ（冪等・誤更新防止） |
+| 次 Status が現在 Status と同一（既に `AI Review`） | スキップ |
+| PR from fork | スキップ |
+
+### 5.2 ジョブ失敗
+
+| 条件 | 挙動 |
+| ---- | ---- |
+| PR 本文から Task Issue を解決できない | ジョブ失敗 |
+| Project / Project item を解決できない | ジョブ失敗 |
+
+## 6. Slack 通知
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 通知レベル | `info` |
+| タイトル | 再AI Review可能 |
+| 必須リンク | PR、Issue |
+| 次 Status | `AI Review` |
+| humanAction | `/review-pr` を実行 |
+| thread 単位 | PR（既存 thread marker があれば返信） |
+
+PR 初回作成時の「PRを作成しました」とは **文面を分離** する。
+
+## 7. 運用上の必須事項
+
+- `/fix-review-comments` は Fix Outcome = `ready_for_ai_review` のとき **必ず** `publish-fix-complete-and-dispatch.cjs` を 1 回実行する（[fix-review-comments.md](../../../.cursor/commands/fix-review-comments.md) §12.5）
+- `split_required` / `partial_fix` 等では dispatch **しない**（Status は `In Progress` 維持）
+- dispatch 忘れ時は `--verify` / `--dispatch-only` / `workflow_dispatch` で recovery
+- 人間が手動修正した場合（パターン B）は Fixer CLI を実行せず、**workflow_dispatch** または手動 Status 更新 + `/review-pr`
+- Machine account PAT（`GH_BOT_TOKEN`）で PR コメント投稿・dispatch すること
+
+## 8. 関連ドキュメント
+
+- [PRレビュー完了時Status更新ワークフロー仕様書.md](./PRレビュー完了時Status更新ワークフロー仕様書.md) … AI/Human Review 完了時
+- [PR作成時Status更新ワークフロー仕様書.md](./PR作成時Status更新・Slack通知ワークフロー仕様書.md) … PR 初回 open 時
+- [Commands設計書.md](../../00_共通/AIエージェント運用/Commands設計書.md) §18
+- [Projects運用ルール.md](../../00_共通/プロジェクト管理/Projects運用ルール.md) §17.3

--- a/docs/06_実装設計/github_actions/README.md
+++ b/docs/06_実装設計/github_actions/README.md
@@ -8,6 +8,7 @@
 | [Planned Startに基づくStatus自動更新ワークフロー.md](./Planned%20Startに基づくStatus自動更新ワークフロー.md) | `update-projects-status-by-planned-start.yml` | Backlog → Todo |
 | [Slack通知共通ワークフロー仕様書.md](./Slack通知共通ワークフロー仕様書.md) | `slack-notify-manual.yml` / `.github/scripts/slack-notify.cjs` | Slack通知の共通仕様・手動通知 |
 | [PR作成時Status更新ワークフロー仕様書.md](./PR作成時Status更新ワークフロー仕様書.md) | `pr-created-status-and-slack.yml` | PR作成時の `AI Review` 更新・Slack通知 |
+| [PR再AI Review待ちStatus更新ワークフロー仕様書.md](./PR%E5%86%8DAI%20Review%E5%BE%85%E3%81%A1Status%E6%9B%B4%E6%96%B0%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC%E4%BB%81%E6%A7%98%E6%9B%B8.md) | `pr-ready-for-ai-review.yml` | fix 完了後の `In Progress` → `AI Review` 更新・Slack通知 |
 | [PRレビュー完了時Status更新ワークフロー仕様書.md](./PRレビュー完了時Status更新ワークフロー仕様書.md) | `pr-review-status-sync.yml` | AI/Human レビュー完了時の Status 更新・Slack通知 |
 | [PR merge時Status更新ワークフロー仕様書.md](./PR%20merge時Status更新ワークフロー仕様書.md) | `pr-merged-done-and-slack.yml` | PR merge 時の `Done` 更新・Issue close・Slack通知 |
 | [Definition Run Harnessワークフロー仕様書.md](./Definition%20Run%20Harness%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC%E4%BB%95%E6%A7%98%E6%9B%B8.md) | `definition-run.yml` / `.github/scripts/definition-run-prompt-builder.cjs` / `.github/scripts/definition-run-post-verify.cjs` | 外部トリガから Cursor Cloud Agent に Definition Run を依頼する Harness（MVP: `/start-epic` dry-run のみ） |

--- a/docs/06_実装設計/github_actions/Slack通知共通ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/Slack通知共通ワークフロー仕様書.md
@@ -104,6 +104,7 @@ token実値、Authorization header、Slack API request body中のsecretは出力
 | -------- | ---- |
 | `.github/workflows/issue-metadata-project-branch.yml` | Issue作成通知 |
 | `.github/workflows/pr-created-status-and-slack.yml` | PR作成通知、AI Review遷移通知 |
+| `.github/workflows/pr-ready-for-ai-review.yml` | fix 完了後の再 AI Review 通知、In Progress → AI Review |
 | `.github/workflows/pr-review-status-sync.yml` | AI Review完了通知、Human Review依頼、修正必要通知 |
 | `.github/workflows/pr-merged-done-and-slack.yml` | PR merge / Done通知 |
 | `.github/workflows/slack-notify-manual.yml` | 人間判断、incident、横断影響、レビュー指摘対応完了 |

--- a/prompts/templates/review/fix-complete-comment.md
+++ b/prompts/templates/review/fix-complete-comment.md
@@ -1,0 +1,67 @@
+# Fix Review Comments Result
+
+正本テンプレート。`/fix-review-comments` 完了時に PR へ投稿し、`publish-fix-complete-and-dispatch.cjs` が Fix Outcome を読み取って Status 同期を dispatch する。
+
+## 1. 対応結果
+
+| 項目 | 内容 |
+| ---- | ---- |
+| Fix Outcome | `ready_for_ai_review` |
+| 対象PR | `#<PR番号>` |
+| 対象Issue | `#<Issue番号>` |
+| 対象Branch | `<branch名>` |
+
+### 対応した指摘
+
+- （箇条書き）
+
+### 修正内容
+
+- （箇条書き）
+
+### 変更ファイル
+
+- （箇条書き）
+
+### 再実行したテスト・検証
+
+- （箇条書き）
+
+### 未対応の指摘
+
+- なし
+
+### 未対応理由
+
+- なし
+
+### Human確認事項
+
+- なし
+
+## 12. Status更新意図
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 現在Status | `In Progress` |
+| 次Status | `AI Review` |
+
+### 次に実行するCommand
+
+```text
+/review-pr @<review-definition> #<PR番号>
+```
+
+---
+
+## Fix Outcome 値
+
+| Fix Outcome | Status dispatch | 意味 |
+| ----------- | --------------- | ---- |
+| `ready_for_ai_review` | **実行する** | 指摘対応完了・再 AI Review 可能 |
+| `needs_human_decision` | 実行しない | Human 判断待ち |
+| `split_required` | 実行しない | 別 Issue 化が必要 |
+| `partial_fix` | 実行しない | 一部対応・再レビュー不可 |
+| `blocked` | 実行しない | 前提不足で対応不可 |
+
+`ready_for_ai_review` 以外の場合も PR コメントは投稿してよいが、`publish-fix-complete-and-dispatch.cjs` は dispatch をスキップする。


### PR DESCRIPTION
## Summary

- `publish-fix-complete-and-dispatch.cjs` で fix 完了コメント + `repository_dispatch` を1回実行
- `pr-ready-for-ai-review.yml` で `In Progress` → `AI Review` + Slack「再AI Review可能」
- `fix-review-comments.md` §12.5、仕様書・テンプレート追加

## Test plan

- [x] `node --test`（fix 関連 30 pass）
- [x] `verify-fix-complete-dispatch.sh` ローカル検証
- [ ] feature branch で `workflow_dispatch` dry_run
- [ ] merge 後: `publish-fix-complete-and-dispatch` live E2E
