### PR TITLE
feat: auto-dispatch review-pr when Status becomes AI Review

### DIFF
--- a/.github/scripts/dispatch-definition-run.cjs
+++ b/.github/scripts/dispatch-definition-run.cjs
@@ -1,0 +1,242 @@
+"use strict";
+
+const builder = require("./definition-run-prompt-builder.cjs");
+
+const EVENT_TYPE = "definition-run";
+
+function nonEmpty(value) {
+  return String(value || "").trim();
+}
+
+function resolveRepository({ owner, repo, repository }) {
+  if (owner && repo) return { owner: nonEmpty(owner), repo: nonEmpty(repo) };
+  const full = nonEmpty(repository) || nonEmpty(process.env.GITHUB_REPOSITORY);
+  if (!full || !full.includes("/")) {
+    throw new Error("repository is required (--owner/--repo or GITHUB_REPOSITORY)");
+  }
+  const [resolvedOwner, resolvedRepo] = full.split("/", 2);
+  return { owner: resolvedOwner, repo: resolvedRepo };
+}
+
+function buildClientPayload({
+  command,
+  definition,
+  runMode,
+  targetPr,
+  requestIssue,
+  requestedBy,
+  workspaceRoot,
+}) {
+  const cmd = nonEmpty(command) || "review-pr";
+  const def = nonEmpty(definition);
+  const mode = nonEmpty(runMode) || "live-run";
+  if (!def) throw new Error("definition is required");
+  if (!def.startsWith(builder.DEFINITION_PATH_PREFIX)) {
+    throw new Error(`definition must start with ${builder.DEFINITION_PATH_PREFIX}`);
+  }
+
+  builder.buildDefinitionRunRequest(
+    {
+      command: cmd,
+      definition: def,
+      run_mode: mode,
+      target_pr: nonEmpty(targetPr),
+      request_issue: nonEmpty(requestIssue),
+      requested_by: nonEmpty(requestedBy),
+    },
+    { workspace: nonEmpty(workspaceRoot) || process.cwd() },
+  );
+
+  const payload = {
+    command: cmd,
+    definition: def,
+    run_mode: mode,
+  };
+  const pr = nonEmpty(targetPr);
+  if (pr) payload.target_pr = pr;
+  const issue = nonEmpty(requestIssue);
+  if (issue) payload.request_issue = issue;
+  const by = nonEmpty(requestedBy);
+  if (by) payload.requested_by = by;
+  return payload;
+}
+
+function dispatchUrl(owner, repo) {
+  return `https://api.github.com/repos/${owner}/${repo}/dispatches`;
+}
+
+async function dispatchDefinitionRun({
+  owner,
+  repo,
+  repository,
+  command,
+  definition,
+  runMode,
+  targetPr,
+  requestIssue,
+  requestedBy,
+  workspaceRoot,
+  token,
+  dryRun,
+  fetchImpl,
+}) {
+  const resolved = resolveRepository({ owner, repo, repository });
+  const authToken = nonEmpty(token) || nonEmpty(process.env.GITHUB_TOKEN) || nonEmpty(process.env.GH_TOKEN);
+  if (!authToken) {
+    throw new Error("GITHUB_TOKEN or GH_TOKEN is required to dispatch repository_dispatch");
+  }
+  const workspace = nonEmpty(workspaceRoot) || process.cwd();
+  const clientPayload = buildClientPayload({
+    command,
+    definition,
+    runMode,
+    targetPr,
+    requestIssue,
+    requestedBy,
+    workspaceRoot: workspace,
+  });
+
+  if (dryRun) {
+    return {
+      ok: true,
+      dryRun: true,
+      eventType: EVENT_TYPE,
+      owner: resolved.owner,
+      repo: resolved.repo,
+      clientPayload,
+    };
+  }
+
+  const send = fetchImpl || global.fetch;
+  if (typeof send !== "function") {
+    throw new Error("fetch is unavailable");
+  }
+
+  const response = await send(dispatchUrl(resolved.owner, resolved.repo), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${authToken}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: JSON.stringify({
+      event_type: EVENT_TYPE,
+      client_payload: clientPayload,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`repository_dispatch failed: HTTP ${response.status} ${text}`.trim());
+  }
+
+  return {
+    ok: true,
+    eventType: EVENT_TYPE,
+    owner: resolved.owner,
+    repo: resolved.repo,
+    clientPayload,
+  };
+}
+
+function parseCliArgs(argv) {
+  const args = argv.slice(2);
+  const options = {
+    owner: "",
+    repo: "",
+    repository: "",
+    command: "review-pr",
+    definition: "",
+    runMode: "live-run",
+    targetPr: "",
+    requestIssue: "",
+    requestedBy: "",
+    dryRun: false,
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--owner") {
+      options.owner = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repository" || arg === "-R") {
+      options.repository = args[++i] || "";
+      continue;
+    }
+    if (arg === "--command") {
+      options.command = args[++i] || "";
+      continue;
+    }
+    if (arg === "--definition") {
+      options.definition = args[++i] || "";
+      continue;
+    }
+    if (arg === "--run-mode") {
+      options.runMode = args[++i] || "";
+      continue;
+    }
+    if (arg === "--target-pr" || arg === "--pr") {
+      options.targetPr = args[++i] || "";
+      continue;
+    }
+    if (arg === "--request-issue" || arg === "--issue") {
+      options.requestIssue = args[++i] || "";
+      continue;
+    }
+    if (arg === "--requested-by") {
+      options.requestedBy = args[++i] || "";
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node .github/scripts/dispatch-definition-run.cjs \\
+    --definition prompts/definitions/.../pr-review.yaml \\
+    --target-pr <number> \\
+    [--command review-pr] [--run-mode live-run] \\
+    [--request-issue <number>] [--requested-by <id>] \\
+    [--repository owner/repo] [--dry-run]
+
+Dispatches repository event "${EVENT_TYPE}" to run Definition Run Harness.
+`);
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv);
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  const result = await dispatchDefinitionRun(options);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  EVENT_TYPE,
+  buildClientPayload,
+  dispatchDefinitionRun,
+};

--- a/.github/scripts/dispatch-review-pr-harness.cjs
+++ b/.github/scripts/dispatch-review-pr-harness.cjs
@@ -1,0 +1,325 @@
+"use strict";
+
+const slack = require("./slack-notify.cjs");
+const resolver = require("./resolve-review-definition.cjs");
+const harness = require("./dispatch-definition-run.cjs");
+
+function nonEmpty(value) {
+  return String(value || "").trim();
+}
+
+function resolveRepository({ owner, repo, repository }) {
+  if (owner && repo) return { owner: nonEmpty(owner), repo: nonEmpty(repo) };
+  const full = nonEmpty(repository) || nonEmpty(process.env.GITHUB_REPOSITORY);
+  if (!full || !full.includes("/")) {
+    throw new Error("repository is required (--owner/--repo or GITHUB_REPOSITORY)");
+  }
+  const [resolvedOwner, resolvedRepo] = full.split("/", 2);
+  return { owner: resolvedOwner, repo: resolvedRepo };
+}
+
+function authHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function fetchJson(url, token, fetchImpl) {
+  const send = fetchImpl || global.fetch;
+  const response = await send(url, { headers: authHeaders(token) });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`GitHub API failed: HTTP ${response.status} ${text}`.trim());
+  }
+  return response.json();
+}
+
+async function loadPullRequest({ owner, repo, prNumber, token, fetchImpl }) {
+  return fetchJson(
+    `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`,
+    token,
+    fetchImpl,
+  );
+}
+
+async function loadIssue({ owner, repo, issueNumber, token, fetchImpl }) {
+  return fetchJson(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`,
+    token,
+    fetchImpl,
+  );
+}
+
+function shouldSkipForContext({ context, fixOutcome }) {
+  const ctx = nonEmpty(context);
+  if (ctx === "fix-ready") {
+    const normalized = slack.normalizeKnownFixOutcome(fixOutcome) || "ready_for_ai_review";
+    return normalized !== "ready_for_ai_review"
+      ? { skip: true, reason: "fix_outcome_not_ready_for_ai_review", fix_outcome: normalized }
+      : { skip: false };
+  }
+  return { skip: false };
+}
+
+function buildRecoveryCommand({ owner, repo, prNumber, definition, issueNumber, requestedBy }) {
+  const parts = [
+    "node .github/scripts/dispatch-review-pr-harness.cjs",
+    `--repository ${owner}/${repo}`,
+    `--pr ${prNumber}`,
+  ];
+  if (definition) parts.push(`--definition ${definition}`);
+  if (issueNumber) parts.push(`--issue ${issueNumber}`);
+  if (requestedBy) parts.push(`--requested-by ${requestedBy}`);
+  return parts.join(" \\\n  ");
+}
+
+async function dispatchReviewPrHarness({
+  owner,
+  repo,
+  repository,
+  prNumber,
+  issueNumber,
+  definition,
+  requestedBy,
+  context,
+  fixOutcome,
+  workspaceRoot,
+  token,
+  dryRun,
+  fetchImpl,
+}) {
+  const resolvedRepo = resolveRepository({ owner, repo, repository });
+  const authToken = nonEmpty(token) || nonEmpty(process.env.GITHUB_TOKEN) || nonEmpty(process.env.GH_TOKEN);
+  if (!authToken) {
+    throw new Error("GITHUB_TOKEN or GH_TOKEN is required");
+  }
+
+  const contextGate = shouldSkipForContext({ context, fixOutcome });
+  if (contextGate.skip) {
+    return { ok: true, skipped: true, ...contextGate };
+  }
+
+  const pr = Number(prNumber);
+  if (!Number.isInteger(pr) || pr <= 0) {
+    throw new Error(`Invalid pr_number: ${prNumber}`);
+  }
+
+  const pull = await loadPullRequest({
+    owner: resolvedRepo.owner,
+    repo: resolvedRepo.repo,
+    prNumber: pr,
+    token: authToken,
+    fetchImpl,
+  });
+
+  const repositoryFullName = `${resolvedRepo.owner}/${resolvedRepo.repo}`;
+  if (pull.head?.repo?.full_name !== repositoryFullName) {
+    return { ok: true, skipped: true, reason: "fork_pr" };
+  }
+
+  const relatedIssue =
+    Number(issueNumber) ||
+    Number(slack.relatedIssueNumber(pull.body || "")) ||
+    resolver.parseBranchRef(pull.head?.ref || "")?.issueNumber ||
+    null;
+
+  let issueBody = "";
+  if (relatedIssue) {
+    const issue = await loadIssue({
+      owner: resolvedRepo.owner,
+      repo: resolvedRepo.repo,
+      issueNumber: relatedIssue,
+      token: authToken,
+      fetchImpl,
+    });
+    issueBody = issue.body || "";
+  }
+
+  const workspace = nonEmpty(workspaceRoot) || process.cwd();
+  const reviewResolution = resolver.resolveReviewDefinition({
+    workspaceRoot: workspace,
+    prBody: pull.body || "",
+    issueBody,
+    headRef: pull.head?.ref || "",
+    issueNumber: relatedIssue,
+    definitionOverride: definition,
+  });
+
+  if (!reviewResolution.ok) {
+    return {
+      ok: false,
+      reason: reviewResolution.reason,
+      pr_number: String(pr),
+      issue_number: relatedIssue ? String(relatedIssue) : null,
+      details: reviewResolution,
+      recovery_command: buildRecoveryCommand({
+        owner: resolvedRepo.owner,
+        repo: resolvedRepo.repo,
+        prNumber: pr,
+        issueNumber: relatedIssue,
+        requestedBy,
+      }),
+    };
+  }
+
+  const aiReviewGate = resolver.resolveAiReviewRequired({
+    workspaceRoot: workspace,
+    reviewDefinitionPath: reviewResolution.path,
+  });
+  if (aiReviewGate.ok && aiReviewGate.required === false) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: "ai_review_not_required",
+      review_definition: reviewResolution.path,
+      task_definition: aiReviewGate.task_definition || null,
+    };
+  }
+
+  const dispatchResult = await harness.dispatchDefinitionRun({
+    owner: resolvedRepo.owner,
+    repo: resolvedRepo.repo,
+    command: "review-pr",
+    definition: reviewResolution.path,
+    runMode: "live-run",
+    targetPr: String(pr),
+    requestIssue: relatedIssue ? String(relatedIssue) : "",
+    requestedBy: nonEmpty(requestedBy) || nonEmpty(context) || "ai-review-auto-dispatch",
+    workspaceRoot: workspace,
+    token: authToken,
+    dryRun,
+    fetchImpl,
+  });
+
+  return {
+    ok: true,
+    pr_number: String(pr),
+    issue_number: relatedIssue ? String(relatedIssue) : null,
+    review_definition: reviewResolution.path,
+    review_definition_source: reviewResolution.source,
+    ai_review_required: true,
+    dispatch: dispatchResult,
+  };
+}
+
+function parseCliArgs(argv) {
+  const args = argv.slice(2);
+  const options = {
+    owner: "",
+    repo: "",
+    repository: "",
+    prNumber: "",
+    issueNumber: "",
+    definition: "",
+    requestedBy: "",
+    context: "",
+    fixOutcome: "",
+    workspaceRoot: "",
+    dryRun: false,
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--owner") {
+      options.owner = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repository" || arg === "-R") {
+      options.repository = args[++i] || "";
+      continue;
+    }
+    if (arg === "--pr" || arg === "--pr-number") {
+      options.prNumber = args[++i] || "";
+      continue;
+    }
+    if (arg === "--issue" || arg === "--request-issue") {
+      options.issueNumber = args[++i] || "";
+      continue;
+    }
+    if (arg === "--definition") {
+      options.definition = args[++i] || "";
+      continue;
+    }
+    if (arg === "--requested-by") {
+      options.requestedBy = args[++i] || "";
+      continue;
+    }
+    if (arg === "--context") {
+      options.context = args[++i] || "";
+      continue;
+    }
+    if (arg === "--fix-outcome") {
+      options.fixOutcome = args[++i] || "";
+      continue;
+    }
+    if (arg === "--workspace") {
+      options.workspaceRoot = args[++i] || "";
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node .github/scripts/dispatch-review-pr-harness.cjs \\
+    --repository owner/repo \\
+    --pr <number> \\
+    [--definition prompts/definitions/.../pr-review.yaml] \\
+    [--issue <number>] [--requested-by <id>] \\
+    [--context pr-created|fix-ready] [--fix-outcome ready_for_ai_review] \\
+    [--workspace <path>] [--dry-run]
+
+Resolves Review Definition and dispatches Definition Run Harness (review-pr live-run).
+`);
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv);
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  const result = await dispatchReviewPrHarness({
+    owner: options.owner,
+    repo: options.repo,
+    repository: options.repository,
+    prNumber: options.prNumber,
+    issueNumber: options.issueNumber,
+    definition: options.definition,
+    requestedBy: options.requestedBy,
+    context: options.context,
+    fixOutcome: options.fixOutcome,
+    workspaceRoot: options.workspaceRoot,
+    dryRun: options.dryRun,
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (result.ok === false) process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  dispatchReviewPrHarness,
+  shouldSkipForContext,
+  buildRecoveryCommand,
+};

--- a/.github/scripts/dispatch-review-pr-harness.test.cjs
+++ b/.github/scripts/dispatch-review-pr-harness.test.cjs
@@ -1,0 +1,145 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const harness = require("./dispatch-definition-run.cjs");
+const auto = require("./dispatch-review-pr-harness.cjs");
+
+function write(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function jsonResponse(data) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  };
+}
+
+test("buildClientPayload: review-pr live-run payload", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dispatch-run-"));
+  const definition = "prompts/definitions/_examples/review-definition.example.yaml";
+  write(path.join(root, definition), 'definition_type: "review"\n');
+  const payload = harness.buildClientPayload({
+    command: "review-pr",
+    definition,
+    runMode: "live-run",
+    targetPr: "290",
+    requestIssue: "289",
+    requestedBy: "pr-created-status-sync",
+    workspaceRoot: root,
+  });
+  assert.equal(payload.command, "review-pr");
+  assert.equal(payload.run_mode, "live-run");
+  assert.equal(payload.target_pr, "290");
+  assert.equal(payload.request_issue, "289");
+});
+
+test("dispatchDefinitionRun: dry_run では API を呼ばない", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dispatch-run-"));
+  const definition = "prompts/definitions/_examples/review-definition.example.yaml";
+  write(path.join(root, definition), 'definition_type: "review"\n');
+  let called = false;
+  const result = await harness.dispatchDefinitionRun({
+    owner: "o",
+    repo: "r",
+    definition,
+    targetPr: "1",
+    workspaceRoot: root,
+    token: "token",
+    dryRun: true,
+    fetchImpl: async () => {
+      called = true;
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(called, false);
+});
+
+test("dispatchReviewPrHarness: ai_review_not_required は skipped", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dispatch-auto-"));
+  const taskPath = "prompts/definitions/_e2e/sample/task.yaml";
+  const reviewPath = "prompts/definitions/_e2e/sample/pr-review.yaml";
+  write(path.join(root, taskPath), 'definition_type: "task"\nreview:\n  ai_review_required: false\n');
+  write(
+    path.join(root, reviewPath),
+    `definition_type: "review"\ntarget:\n  task_definition: "${taskPath}"\n`,
+  );
+
+  const result = await auto.dispatchReviewPrHarness({
+    owner: "o",
+    repo: "r",
+    prNumber: 10,
+    issueNumber: 9,
+    definition: reviewPath,
+    workspaceRoot: root,
+    token: "token",
+    fetchImpl: async (url) => {
+      if (url.includes("/pulls/10")) {
+        return jsonResponse({
+          body: "Related to #9",
+          head: { ref: "docs/task-9-sample", repo: { full_name: "o/r" } },
+        });
+      }
+      if (url.includes("/issues/9")) {
+        return jsonResponse({ body: "" });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.equal(result.reason, "ai_review_not_required");
+});
+
+test("dispatchReviewPrHarness: 解決成功時に definition-run を dispatch", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dispatch-auto-"));
+  const taskPath = "prompts/definitions/_e2e/sample/task.yaml";
+  const reviewPath = "prompts/definitions/_e2e/sample/pr-review.yaml";
+  write(path.join(root, taskPath), 'definition_type: "task"\nreview:\n  ai_review_required: true\n');
+  write(
+    path.join(root, reviewPath),
+    `definition_type: "review"\ntarget:\n  task_definition: "${taskPath}"\n`,
+  );
+
+  let dispatchBody = null;
+  const result = await auto.dispatchReviewPrHarness({
+    owner: "o",
+    repo: "r",
+    prNumber: 10,
+    issueNumber: 9,
+    definition: reviewPath,
+    requestedBy: "test",
+    workspaceRoot: root,
+    token: "token",
+    fetchImpl: async (url, init) => {
+      if (url.includes("/pulls/10")) {
+        return jsonResponse({
+          body: "Related to #9",
+          head: { ref: "docs/task-9-sample", repo: { full_name: "o/r" } },
+        });
+      }
+      if (url.includes("/issues/9")) {
+        return jsonResponse({ body: "" });
+      }
+      if (url.endsWith("/dispatches") && init?.method === "POST") {
+        dispatchBody = JSON.parse(init.body);
+        return { ok: true, status: 204, text: async () => "" };
+      }
+      throw new Error(`unexpected url: ${url}`);
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(dispatchBody.event_type, "definition-run");
+  assert.equal(dispatchBody.client_payload.command, "review-pr");
+  assert.equal(dispatchBody.client_payload.definition, reviewPath);
+  assert.equal(dispatchBody.client_payload.target_pr, "10");
+});

--- a/.github/scripts/resolve-review-definition.cjs
+++ b/.github/scripts/resolve-review-definition.cjs
@@ -1,0 +1,303 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const DEFINITION_ROOT = "prompts/definitions/";
+const REVIEW_FILE_NAME = "pr-review.yaml";
+
+function nonEmpty(value) {
+  return String(value || "").trim();
+}
+
+function normalizePath(value) {
+  const raw = nonEmpty(value).replace(/\\/g, "/");
+  if (!raw) return "";
+  return raw.startsWith(DEFINITION_ROOT) ? raw : "";
+}
+
+function parseBranchRef(headRef) {
+  const ref = nonEmpty(headRef);
+  const match = /(?:^|\/)(epic|task)-(\d+)-([a-z0-9-]+)$/i.exec(ref);
+  if (!match) return null;
+  return {
+    unit: match[1].toLowerCase(),
+    issueNumber: Number(match[2]),
+    summary: match[3].toLowerCase(),
+  };
+}
+
+function extractDefinitionPathsFromText(text) {
+  const paths = new Set();
+  const body = String(text || "");
+
+  for (const match of body.matchAll(/\/review-pr\s+@([^\s#`]+)/gi)) {
+    const candidate = normalizePath(match[1]);
+    if (candidate) paths.add(candidate);
+  }
+
+  for (const match of body.matchAll(
+    /(?:Review Definition|review_definition|ReviewDefinition)\s*[:：]\s*`?([^\s`#]+\.ya?ml)`?/gi,
+  )) {
+    const candidate = normalizePath(match[1]);
+    if (candidate) paths.add(candidate);
+  }
+
+  return [...paths];
+}
+
+function readFileSafe(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function fileExists(filePath) {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function extractYamlScalar(content, key) {
+  const pattern = new RegExp(`^\\s*${key}:\\s*"?([^"\\n#]+)"?`, "m");
+  const match = pattern.exec(String(content || ""));
+  return match ? nonEmpty(match[1]) : "";
+}
+
+function extractTaskDefinitionPath(reviewContent) {
+  const targetBlock = /target:\s*[\s\S]*?(?=\n[a-z_]+:|\n\S|\s*$)/i.exec(String(reviewContent || ""));
+  const block = targetBlock ? targetBlock[0] : reviewContent;
+  return normalizePath(extractYamlScalar(block, "task_definition"));
+}
+
+function extractTargetIssueNumber(reviewContent) {
+  const issueBlock = /target:\s*[\s\S]*?(?=\n[a-z_]+:|\n\S|\s*$)/i.exec(String(reviewContent || ""));
+  const block = issueBlock ? issueBlock[0] : reviewContent;
+  const issueSection = /issue:\s*[\s\S]*?(?=\n\s{0,2}[a-z_]+:|\s*$)/i.exec(block);
+  const scoped = issueSection ? issueSection[0] : block;
+  const value = extractYamlScalar(scoped, "number");
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function extractAiReviewRequired(taskContent) {
+  const reviewBlock = /review:\s*[\s\S]*?(?=\n[a-z_]+:|\n\S|\s*$)/i.exec(String(taskContent || ""));
+  const block = reviewBlock ? reviewBlock[0] : taskContent;
+  const value = extractYamlScalar(block, "ai_review_required").toLowerCase();
+  if (value === "false") return false;
+  if (value === "true") return true;
+  return true;
+}
+
+function listReviewDefinitionFiles(workspaceRoot) {
+  const root = path.join(workspaceRoot, DEFINITION_ROOT);
+  const results = [];
+
+  function walk(current) {
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (entry.isFile() && entry.name === REVIEW_FILE_NAME) {
+        results.push(full);
+      }
+    }
+  }
+
+  walk(root);
+  return results.map((absolute) => absolute.replace(/\\/g, "/").slice(workspaceRoot.replace(/\\/g, "/").length + 1));
+}
+
+function siblingReviewDefinitionForTask(taskDefinitionPath, workspaceRoot) {
+  const taskPath = normalizePath(taskDefinitionPath);
+  if (!taskPath) return "";
+  const absoluteTask = path.join(workspaceRoot, taskPath);
+  const sibling = path.join(path.dirname(absoluteTask), REVIEW_FILE_NAME);
+  if (!fileExists(sibling)) return "";
+  return sibling.replace(/\\/g, "/").slice(workspaceRoot.replace(/\\/g, "/").length + 1);
+}
+
+function findTaskDefinitionBySummary(workspaceRoot, summary) {
+  const matches = [];
+  const root = path.join(workspaceRoot, DEFINITION_ROOT);
+
+  function walk(current) {
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name.toLowerCase() === summary) {
+          for (const candidate of ["task.yaml", `${summary}.yaml`]) {
+            const taskFile = path.join(full, candidate);
+            if (fileExists(taskFile)) {
+              matches.push(
+                taskFile.replace(/\\/g, "/").slice(workspaceRoot.replace(/\\/g, "/").length + 1),
+              );
+            }
+          }
+        }
+        walk(full);
+      }
+    }
+  }
+
+  walk(root);
+  return matches;
+}
+
+function scoreReviewCandidate(relativePath, { issueNumber, branchInfo, taskDefinitionPath, workspaceRoot }) {
+  const absolute = path.join(workspaceRoot, relativePath);
+  const content = readFileSafe(absolute);
+  if (!content.includes('definition_type: "review"') && !content.includes("definition_type: review")) {
+    return 0;
+  }
+
+  let score = 1;
+  const targetIssue = extractTargetIssueNumber(content);
+  const linkedTask = extractTaskDefinitionPath(content);
+
+  if (issueNumber && targetIssue === issueNumber) score += 100;
+  if (taskDefinitionPath && linkedTask === taskDefinitionPath) score += 100;
+
+  if (branchInfo?.summary) {
+    const summary = branchInfo.summary;
+    if (relativePath.toLowerCase().includes(`/${summary}/`)) score += 40;
+    if (linkedTask.toLowerCase().includes(`/${summary}/`) || linkedTask.toLowerCase().includes(`/${summary}.`)) {
+      score += 40;
+    }
+  }
+
+  return score;
+}
+
+function resolveReviewDefinition({
+  workspaceRoot,
+  prBody = "",
+  issueBody = "",
+  headRef = "",
+  issueNumber = null,
+  definitionOverride = "",
+  taskDefinitionOverride = "",
+}) {
+  const workspace = nonEmpty(workspaceRoot) || process.cwd();
+  const explicit = normalizePath(definitionOverride);
+  if (explicit) {
+    const absolute = path.join(workspace, explicit);
+    if (!fileExists(absolute)) {
+      return { ok: false, reason: "definition_override_missing", path: explicit };
+    }
+    return { ok: true, path: explicit, source: "override" };
+  }
+
+  const fromText = [
+    ...extractDefinitionPathsFromText(prBody),
+    ...extractDefinitionPathsFromText(issueBody),
+  ];
+  const validFromText = fromText.filter((candidate) => fileExists(path.join(workspace, candidate)));
+  if (validFromText.length === 1) {
+    return { ok: true, path: validFromText[0], source: "pr_or_issue_body" };
+  }
+  if (validFromText.length > 1) {
+    return { ok: false, reason: "ambiguous_definition_in_text", paths: validFromText };
+  }
+
+  const branchInfo = parseBranchRef(headRef);
+  const resolvedIssueNumber = issueNumber || branchInfo?.issueNumber || null;
+
+  const taskOverride = normalizePath(taskDefinitionOverride);
+  const taskCandidates = new Set();
+  if (taskOverride && fileExists(path.join(workspace, taskOverride))) {
+    taskCandidates.add(taskOverride);
+  }
+  if (branchInfo?.summary) {
+    for (const taskPath of findTaskDefinitionBySummary(workspace, branchInfo.summary)) {
+      taskCandidates.add(taskPath);
+    }
+    const e2eReview = `${DEFINITION_ROOT}_e2e/${branchInfo.summary}/${REVIEW_FILE_NAME}`;
+    if (fileExists(path.join(workspace, e2eReview))) {
+      return { ok: true, path: e2eReview, source: "e2e_branch_summary" };
+    }
+  }
+
+  for (const taskPath of taskCandidates) {
+    const sibling = siblingReviewDefinitionForTask(taskPath, workspace);
+    if (sibling) {
+      return { ok: true, path: sibling, source: "task_sibling", task_definition: taskPath };
+    }
+  }
+
+  const scored = listReviewDefinitionFiles(workspace)
+    .map((relativePath) => ({
+      path: relativePath,
+      score: scoreReviewCandidate(relativePath, {
+        issueNumber: resolvedIssueNumber,
+        branchInfo,
+        taskDefinitionPath: [...taskCandidates][0] || "",
+        workspaceRoot: workspace,
+      }),
+    }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score);
+
+  if (scored.length === 1 || (scored.length > 1 && scored[0].score > scored[1].score)) {
+    return { ok: true, path: scored[0].path, source: "scan", score: scored[0].score };
+  }
+  if (scored.length > 1 && scored[0].score === scored[1].score) {
+    return {
+      ok: false,
+      reason: "ambiguous_review_definition",
+      paths: scored.slice(0, 5).map((entry) => entry.path),
+    };
+  }
+
+  return { ok: false, reason: "review_definition_not_found", headRef, issueNumber: resolvedIssueNumber };
+}
+
+function resolveAiReviewRequired({ workspaceRoot, reviewDefinitionPath, taskDefinitionPath = "" }) {
+  const workspace = nonEmpty(workspaceRoot) || process.cwd();
+  const reviewAbsolute = path.join(workspace, reviewDefinitionPath);
+  const reviewContent = readFileSafe(reviewAbsolute);
+  const linkedTask = normalizePath(taskDefinitionPath) || extractTaskDefinitionPath(reviewContent);
+  if (!linkedTask) return { ok: true, required: true, source: "default" };
+
+  const taskAbsolute = path.join(workspace, linkedTask);
+  if (!fileExists(taskAbsolute)) return { ok: true, required: true, source: "task_missing_default_true" };
+
+  const taskContent = readFileSafe(taskAbsolute);
+  return {
+    ok: true,
+    required: extractAiReviewRequired(taskContent),
+    source: "task_definition",
+    task_definition: linkedTask,
+  };
+}
+
+module.exports = {
+  DEFINITION_ROOT,
+  REVIEW_FILE_NAME,
+  parseBranchRef,
+  extractDefinitionPathsFromText,
+  extractTaskDefinitionPath,
+  extractAiReviewRequired,
+  listReviewDefinitionFiles,
+  resolveReviewDefinition,
+  resolveAiReviewRequired,
+  siblingReviewDefinitionForTask,
+};

--- a/.github/scripts/resolve-review-definition.test.cjs
+++ b/.github/scripts/resolve-review-definition.test.cjs
@@ -1,0 +1,70 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const resolver = require("./resolve-review-definition.cjs");
+
+function write(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+test("parseBranchRef: task branch を分解する", () => {
+  assert.deepEqual(resolver.parseBranchRef("docs/task-289-review-fix-patterns-e2e"), {
+    unit: "task",
+    issueNumber: 289,
+    summary: "review-fix-patterns-e2e",
+  });
+});
+
+test("extractDefinitionPathsFromText: /review-pr @path を抽出する", () => {
+  const paths = resolver.extractDefinitionPathsFromText(
+    "next: /review-pr @prompts/definitions/_e2e/review-fix-patterns-e2e/pr-review.yaml #290",
+  );
+  assert.deepEqual(paths, ["prompts/definitions/_e2e/review-fix-patterns-e2e/pr-review.yaml"]);
+});
+
+test("resolveReviewDefinition: e2e branch summary から sibling pr-review を解決する", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "resolve-review-"));
+  write(
+    path.join(root, "prompts/definitions/_e2e/review-fix-patterns-e2e/task.yaml"),
+    'definition_type: "task"\nreview:\n  ai_review_required: true\n',
+  );
+  write(
+    path.join(root, "prompts/definitions/_e2e/review-fix-patterns-e2e/pr-review.yaml"),
+    'definition_type: "review"\ntarget:\n  task_definition: "prompts/definitions/_e2e/review-fix-patterns-e2e/task.yaml"\n',
+  );
+
+  const result = resolver.resolveReviewDefinition({
+    workspaceRoot: root,
+    headRef: "docs/task-289-review-fix-patterns-e2e",
+    issueNumber: 289,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.path, "prompts/definitions/_e2e/review-fix-patterns-e2e/pr-review.yaml");
+  assert.equal(result.source, "e2e_branch_summary");
+});
+
+test("resolveAiReviewRequired: false のとき required=false", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "resolve-review-"));
+  const taskPath = "prompts/definitions/tasks/sample/task.yaml";
+  write(
+    path.join(root, taskPath),
+    'definition_type: "task"\nreview:\n  ai_review_required: false\n',
+  );
+  const reviewPath = "prompts/definitions/reviews/sample/pr-review.yaml";
+  write(
+    path.join(root, reviewPath),
+    `definition_type: "review"\ntarget:\n  task_definition: "${taskPath}"\n`,
+  );
+
+  const gate = resolver.resolveAiReviewRequired({
+    workspaceRoot: root,
+    reviewDefinitionPath: reviewPath,
+  });
+  assert.equal(gate.required, false);
+});

--- a/.github/workflows/definition-run.yml
+++ b/.github/workflows/definition-run.yml
@@ -1,5 +1,7 @@
 name: Definition Run Harness
 
+run-name: "definition-run · ${{ github.event.client_payload.command || inputs.command || 'unknown' }} · PR #${{ github.event.client_payload.target_pr || inputs.target_pr || 'n/a' }} · ${{ github.event.client_payload.run_mode || inputs.run_mode || 'dry-run' }}"
+
 on:
   repository_dispatch:
     types:

--- a/.github/workflows/pr-created-status-and-slack.yml
+++ b/.github/workflows/pr-created-status-and-slack.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Update Project Status and notify Slack
+        id: sync-status
         uses: actions/github-script@v8
         env:
           PROJECT_OWNER: ${{ vars.PROJECT_OWNER }}
@@ -110,6 +111,16 @@ jobs:
                 if (!items?.pageInfo?.hasNextPage) return null;
                 after = items.pageInfo.endCursor;
               }
+            }
+
+            async function markDispatchAiReview(prNumber, issueNumber) {
+              if (dryRun) {
+                core.setOutput("dispatch_ai_review", "false");
+                return;
+              }
+              core.setOutput("dispatch_ai_review", "true");
+              core.setOutput("pr_number", String(prNumber));
+              core.setOutput("issue_number", String(issueNumber));
             }
 
             async function updateStatus(project, itemId, statusName) {
@@ -202,7 +213,7 @@ jobs:
                 PR: pr.html_url,
                 Issue: `${context.serverUrl}/${repositoryFullName}/issues/${issueNumber}`,
               },
-              humanAction: "AI Reviewを実施します。",
+              humanAction: "Definition Run Harness により AI Review を自動実行します。",
             });
             const result = await slack.postSlackMessage({
               token: process.env.SLACK_BOT_TOKEN,
@@ -243,3 +254,23 @@ jobs:
               core.warning(`Slack notification failed: ${result.error || "unknown"}`);
             }
 
+            await markDispatchAiReview(prNumber, issueNumber);
+
+      - name: Setup Node
+        if: steps.sync-status.outputs.dispatch_ai_review == 'true'
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+
+      - name: Dispatch AI Review via Definition Run Harness
+        if: steps.sync-status.outputs.dispatch_ai_review == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/dispatch-review-pr-harness.cjs \
+            --repository "${{ github.repository }}" \
+            --pr "${{ steps.sync-status.outputs.pr_number }}" \
+            --issue "${{ steps.sync-status.outputs.issue_number }}" \
+            --requested-by "pr-created-status-sync" \
+            --context "pr-created"

--- a/.github/workflows/pr-ready-for-ai-review.yml
+++ b/.github/workflows/pr-ready-for-ai-review.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Update Project Status and notify Slack
+        id: sync-status
         uses: actions/github-script@v8
         env:
           PROJECT_OWNER: ${{ vars.PROJECT_OWNER }}
@@ -65,6 +66,21 @@ jobs:
                 if (value !== undefined && value !== "") lines.push(`${key}: ${value}`);
               }
               return core.summary.addRaw(lines.join("\n") + "\n").write();
+            }
+
+            function markDispatchAiReview(prNumber, issueNumber) {
+              if (dryRun) {
+                core.setOutput("dispatch_ai_review", "false");
+                return;
+              }
+              core.setOutput("dispatch_ai_review", "true");
+              core.setOutput("pr_number", String(prNumber));
+              core.setOutput("issue_number", String(issueNumber));
+            }
+
+            async function skipWithSummaryAndMaybeDispatch(reason, details, prNumber, issueNumber, dispatchReview) {
+              await skipWithSummary(reason, details);
+              if (dispatchReview) await markDispatchAiReview(prNumber, issueNumber);
             }
 
             async function loadProject() {
@@ -227,11 +243,17 @@ jobs:
 
             if (expectedCurrent && currentStatus && !slack.statusNamesEqual(currentStatus, expectedCurrent)) {
               if (slack.statusNamesEqual(currentStatus, nextStatus)) {
-                return skipWithSummary("already_at_next_status", {
-                  PR: `#${prNumber}`,
-                  Issue: `#${issueNumber}`,
-                  Status: currentStatus,
-                });
+                return skipWithSummaryAndMaybeDispatch(
+                  "already_at_next_status",
+                  {
+                    PR: `#${prNumber}`,
+                    Issue: `#${issueNumber}`,
+                    Status: currentStatus,
+                  },
+                  prNumber,
+                  issueNumber,
+                  true,
+                );
               }
               return skipWithSummary("current_status_mismatch", {
                 PR: `#${prNumber}`,
@@ -243,11 +265,17 @@ jobs:
             }
 
             if (currentStatus && slack.statusNamesEqual(currentStatus, nextStatus)) {
-              return skipWithSummary("already_at_next_status", {
-                PR: `#${prNumber}`,
-                Issue: `#${issueNumber}`,
-                Status: currentStatus,
-              });
+              return skipWithSummaryAndMaybeDispatch(
+                "already_at_next_status",
+                {
+                  PR: `#${prNumber}`,
+                  Issue: `#${issueNumber}`,
+                  Status: currentStatus,
+                },
+                prNumber,
+                issueNumber,
+                true,
+              );
             }
 
             await updateStatus(project, itemId, nextStatus);
@@ -272,7 +300,7 @@ jobs:
                 PR: pr.html_url,
                 Issue: `${serverUrl}/${repositoryFullName}/issues/${issueNumber}`,
               },
-              humanAction: "/review-pr を実行してください。",
+              humanAction: "Definition Run Harness により AI Review を自動実行します。",
             });
             const result = await slack.postSlackMessage({
               token: process.env.SLACK_BOT_TOKEN,
@@ -302,3 +330,25 @@ jobs:
             if (!result.ok) {
               core.warning(`Slack notification failed: ${result.error || "unknown"}`);
             }
+
+            await markDispatchAiReview(prNumber, issueNumber);
+
+      - name: Setup Node
+        if: steps.sync-status.outputs.dispatch_ai_review == 'true'
+        uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+
+      - name: Dispatch AI Review via Definition Run Harness
+        if: steps.sync-status.outputs.dispatch_ai_review == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PROJECTS_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          node .github/scripts/dispatch-review-pr-harness.cjs \
+            --repository "${{ github.repository }}" \
+            --pr "${{ steps.sync-status.outputs.pr_number }}" \
+            --issue "${{ steps.sync-status.outputs.issue_number }}" \
+            --requested-by "pr-ready-for-ai-review-status-sync" \
+            --context "fix-ready" \
+            --fix-outcome "ready_for_ai_review"

--- a/docs/00_共通/AIエージェント運用/Commands設計書.md
+++ b/docs/00_共通/AIエージェント運用/Commands設計書.md
@@ -797,6 +797,7 @@ AI Review 完了後の Projects Status 更新は [PR Review Status Sync](../../0
 | 完了確認 | 同一 CLI の `--verify` |
 | recovery | `--dispatch-only`（コメント投稿済み時） |
 | Harness | `review-pr` + `live-run` 完了後、post-run 検証で dispatch 忘れを **ジョブ失敗** |
+| Status=`AI Review` 自動起動 | `pr-created-status-and-slack.yml` / `pr-ready-for-ai-review.yml` が `dispatch-review-pr-harness.cjs` で Harness を dispatch（[AI Review自動起動ワークフロー連携仕様書](../../06_実装設計/github_actions/AI%20Review自動起動ワークフロー連携仕様書.md)） |
 | Machine account | dispatch / PR コメント投稿前に `GH_BOT_TOKEN` で bot 認証（[AI機械アカウント運用設計書](./AI機械アカウント運用設計書.md)） |
 
 詳細手順は `.cursor/commands/review-pr.md` §15.5 を正本とする。

--- a/docs/06_実装設計/github_actions/AI Review自動起動ワークフロー連携仕様書.md
+++ b/docs/06_実装設計/github_actions/AI Review自動起動ワークフロー連携仕様書.md
@@ -1,0 +1,70 @@
+# AI Review 自動起動ワークフロー連携仕様書
+
+## 1. 目的
+
+Projects Status が `AI Review` になったタイミングで、Definition Run Harness 経由の `/review-pr`（`live-run`）を **自動起動** し、AI Review 完了後に Status が `Human Review` または `In Progress` へ進むまで滞留させない。
+
+Status 更新のみで `/review-pr` が手動待ちになる運用ギャップを解消する。
+
+## 2. 実装ファイル
+
+| 種別 | ファイル | 役割 |
+| ---- | -------- | ---- |
+| Review Definition 解決 | `.github/scripts/resolve-review-definition.cjs` | PR / Issue / Branch から `pr-review.yaml` を解決 |
+| Harness dispatch（低レベル） | `.github/scripts/dispatch-definition-run.cjs` | `repository_dispatch` `definition-run` |
+| 正本 CLI | `.github/scripts/dispatch-review-pr-harness.cjs` | 解決 + `ai_review_required` 判定 + Harness dispatch |
+| 単体テスト | `.github/scripts/resolve-review-definition.test.cjs` | 解決ロジック |
+| 単体テスト | `.github/scripts/dispatch-review-pr-harness.test.cjs` | dispatch 連携 |
+| Harness | `.github/workflows/definition-run.yml` | Cursor Cloud Agent で `/review-pr` 実行 |
+| 起動元 workflow | `.github/workflows/pr-created-status-and-slack.yml` | PR open → `AI Review` 後に dispatch |
+| 起動元 workflow | `.github/workflows/pr-ready-for-ai-review.yml` | fix 完了 → `AI Review` 後に dispatch |
+
+## 3. 処理フロー
+
+```text
+PR open / fix-ready (ready_for_ai_review)
+  → Status Sync workflow
+  → Status = AI Review
+  → dispatch-review-pr-harness.cjs
+  → repository_dispatch (definition-run)
+  → Definition Run Harness (review-pr / live-run)
+  → Reviewer AI が publish-ai-review-and-dispatch.cjs
+  → PR Review Status Sync
+  → Human Review または In Progress
+```
+
+## 4. Review Definition 解決順
+
+1. CLI `--definition` 明示指定
+2. PR / Issue 本文の `/review-pr @path` または `Review Definition:` 行
+3. Branch summary から `prompts/definitions/_e2e/{summary}/pr-review.yaml`
+4. Task Definition と同ディレクトリの `pr-review.yaml`
+5. 全 `pr-review.yaml` スキャン（Issue 番号 / task_definition リンク / summary 一致でスコアリング）
+
+解決不能・曖昧な場合は dispatch ステップが **失敗** し、Job Summary / Actions log に recovery コマンドを残す。
+
+## 5. スキップ条件（dispatch しない・ジョブ成功）
+
+| 条件 | 理由 |
+| ---- | ---- |
+| `dry_run=true` | 受入確認 |
+| PR from fork | 既存 Status workflow と同様 |
+| `fix_outcome` ≠ `ready_for_ai_review` | fix-ready 経路のみ |
+| Task Definition で `review.ai_review_required: false` | AI Review 省略 |
+
+## 6. 前提
+
+| 項目 | 内容 |
+| ---- | ---- |
+| Secret | `CURSOR_API_KEY`（Definition Run Harness） |
+| Token | `PROJECTS_TOKEN` または `GITHUB_TOKEN`（`repository_dispatch`） |
+| Review Definition | PR に対応する `pr-review.yaml` がリポジトリに存在すること |
+| Harness 完了後 | Agent が `publish-ai-review-and-dispatch.cjs` を 1 回実行（post-verify で検証） |
+
+## 7. 関連ドキュメント
+
+- [Definition Run Harnessワークフロー仕様書.md](./Definition%20Run%20Harness%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC%E4%BB%98%E6%A7%98%E6%9B%B8.md)
+- [PR作成時Status更新ワークフロー仕様書.md](./PR作成時Status更新・Slack通知ワークフロー仕様書.md)
+- [PR再AI Review待ちStatus更新ワークフロー仕様書.md](./PR%E5%86%8DAI%20Review%E5%BE%85%E3%81%A1Status%E6%9B%B4%E6%96%B0%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC%E4%BB%98%E6%A7%98%E6%9B%B8.md)
+- [PRレビュー完了時Status更新ワークフロー仕様書.md](./PRレビュー完了時Status更新ワークフロー仕様書.md)
+- [Commands設計書.md](../../00_共通/AIエージェント運用/Commands設計書.md) §17

--- a/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
@@ -306,8 +306,8 @@ Definition Run Harness が live-run で Issue を起票した後、以下の既�
 | --- | --- | --- |
 | Issue メタデータ → Project 同期 | `.github/workflows/issue-metadata-project-branch.yml` | Issue 本文に Issue 運用メタデータを正しく埋めて作成のみ |
 | Issue → Branch 作成 | 同上 | Issue 本文 no-branch チェックを正しく設定 |
-| PR 作成時 Status / Slack | `.github/workflows/pr-created-status-and-slack.yml` | PR 作成のみ |
-| fix 完了後 Status / Slack | `.github/workflows/pr-ready-for-ai-review.yml` | **`publish-fix-complete-and-dispatch.cjs` で dispatch**（Fixer 実行） |
+| PR 作成時 Status / Slack | `.github/workflows/pr-created-status-and-slack.yml` | PR 作成のみ。**完了後** `dispatch-review-pr-harness.cjs` で Harness 自動起動 |
+| fix 完了後 Status / Slack | `.github/workflows/pr-ready-for-ai-review.yml` | **`publish-fix-complete-and-dispatch.cjs` で dispatch**（Fixer 実行）。**完了後** Harness 自動起動 |
 | PR レビュー → Status | `.github/workflows/pr-review-status-sync.yml` | **`publish-ai-review-and-dispatch.cjs` で dispatch**（Agent 実行）。Harness live-run 後は post-verify で dispatch 忘れを検証 |
 | PR merge → Done / Slack | `.github/workflows/pr-merged-done-and-slack.yml` | merge は人間判断（AI 不可） |
 | 手動 Slack 通知 | `.github/workflows/slack-notify-manual.yml` | 必要時に `workflow_dispatch` |

--- a/docs/06_実装設計/github_actions/PR作成時Status更新・Slack通知ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PR作成時Status更新・Slack通知ワークフロー仕様書.md
@@ -51,6 +51,7 @@ workflow permissionsは必要最小限にする。
 5. Projects Statusを `AI Review` へ更新する。
 6. Slackに `[info] PRを作成しました` を送信する。
 7. Slack APIの戻り値 `ts` をPRコメントのthread markerに保存する。
+8. Review Definition を解決し、Definition Run Harness（`review-pr` / `live-run`）を `repository_dispatch` で起動する（[AI Review自動起動](./AI%20Review自動起動ワークフロー連携仕様書.md)）。
 
 ## 6. スキップ条件
 

--- a/docs/06_実装設計/github_actions/PR再AI Review待ちStatus更新ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PR再AI Review待ちStatus更新ワークフロー仕様書.md
@@ -15,6 +15,8 @@ Status の正式値は [Projects運用ルール](../../00_共通/プロジェク
 | 実装ファイル | `.github/workflows/pr-ready-for-ai-review.yml` |
 | dispatch CLI | `.github/scripts/dispatch-pr-ready-for-ai-review.cjs` |
 | 正本 CLI（コメント + dispatch） | `.github/scripts/publish-fix-complete-and-dispatch.cjs` |
+| AI Review 自動起動 CLI | `.github/scripts/dispatch-review-pr-harness.cjs` |
+| Review Definition 解決 | `.github/scripts/resolve-review-definition.cjs` |
 | PR コメント正本 | [fix-complete-comment.md](../../../prompts/templates/review/fix-complete-comment.md) |
 | 共通 script | `.github/scripts/slack-notify.cjs` |
 | Actions 表示名 | `PR Ready For AI Review Status Sync` |
@@ -74,7 +76,7 @@ on:
 | タイトル | 再AI Review可能 |
 | 必須リンク | PR、Issue |
 | 次 Status | `AI Review` |
-| humanAction | `/review-pr` を実行 |
+| humanAction | Definition Run Harness により AI Review を自動実行 |
 | thread 単位 | PR（既存 thread marker があれば返信） |
 
 PR 初回作成時の「PRを作成しました」とは **文面を分離** する。
@@ -82,6 +84,7 @@ PR 初回作成時の「PRを作成しました」とは **文面を分離** す
 ## 7. 運用上の必須事項
 
 - `/fix-review-comments` は Fix Outcome = `ready_for_ai_review` のとき **必ず** `publish-fix-complete-and-dispatch.cjs` を 1 回実行する（[fix-review-comments.md](../../../.cursor/commands/fix-review-comments.md) §12.5）
+- Status が `AI Review` になったら、workflow が **Definition Run Harness**（`review-pr` / `live-run`）を自動起動する（[AI Review自動起動ワークフロー連携仕様書.md](./AI%20Review自動起動ワークフロー連携仕様書.md)）
 - `split_required` / `partial_fix` 等では dispatch **しない**（Status は `In Progress` 維持）
 - dispatch 忘れ時は `--verify` / `--dispatch-only` / `workflow_dispatch` で recovery
 - 人間が手動修正した場合（パターン B）は Fixer CLI を実行せず、**workflow_dispatch** または手動 Status 更新 + `/review-pr`

--- a/docs/06_実装設計/github_actions/README.md
+++ b/docs/06_実装設計/github_actions/README.md
@@ -9,6 +9,7 @@
 | [Slack通知共通ワークフロー仕様書.md](./Slack通知共通ワークフロー仕様書.md) | `slack-notify-manual.yml` / `.github/scripts/slack-notify.cjs` | Slack通知の共通仕様・手動通知 |
 | [PR作成時Status更新ワークフロー仕様書.md](./PR作成時Status更新ワークフロー仕様書.md) | `pr-created-status-and-slack.yml` | PR作成時の `AI Review` 更新・Slack通知 |
 | [PR再AI Review待ちStatus更新ワークフロー仕様書.md](./PR%E5%86%8DAI%20Review%E5%BE%85%E3%81%A1Status%E6%9B%B4%E6%96%B0%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC%E4%BB%81%E6%A7%98%E6%9B%B8.md) | `pr-ready-for-ai-review.yml` | fix 完了後の `In Progress` → `AI Review` 更新・Slack通知 |
+| [AI Review自動起動ワークフロー連携仕様書.md](./AI%20Review%E8%87%AA%E5%8B%95%E8%B5%B7%E5%8B%95%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC%E9%80%A3%E6%8B%9F%E4%BB%98%E6%A7%98%E6%9B%B8.md) | `dispatch-review-pr-harness.cjs` / `pr-created-status-and-slack.yml` / `pr-ready-for-ai-review.yml` | Status=`AI Review` 到達時に Definition Run Harness（`review-pr` live-run）を自動起動 |
 | [PRレビュー完了時Status更新ワークフロー仕様書.md](./PRレビュー完了時Status更新ワークフロー仕様書.md) | `pr-review-status-sync.yml` | AI/Human レビュー完了時の Status 更新・Slack通知 |
 | [PR merge時Status更新ワークフロー仕様書.md](./PR%20merge時Status更新ワークフロー仕様書.md) | `pr-merged-done-and-slack.yml` | PR merge 時の `Done` 更新・Issue close・Slack通知 |
 | [Definition Run Harnessワークフロー仕様書.md](./Definition%20Run%20Harness%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC%E4%BB%95%E6%A7%98%E6%9B%B8.md) | `definition-run.yml` / `.github/scripts/definition-run-prompt-builder.cjs` / `.github/scripts/definition-run-post-verify.cjs` | 外部トリガから Cursor Cloud Agent に Definition Run を依頼する Harness（MVP: `/start-epic` dry-run のみ） |


### PR DESCRIPTION
## Summary

- Status が `AI Review` になったタイミング（PR open / fix 完了）で、Definition Run Harness 経由の `/review-pr`（`live-run`）を自動起動する
- Review Definition 解決（`resolve-review-definition.cjs`）と Harness dispatch 正本 CLI（`dispatch-review-pr-harness.cjs`）を追加
- `pr-created-status-and-slack.yml` / `pr-ready-for-ai-review.yml` の Status 更新成功後に dispatch ステップを追加

## Test plan

- [x] `node --test .github/scripts/resolve-review-definition.test.cjs .github/scripts/dispatch-review-pr-harness.test.cjs`（8/8 PASS）
- [x] workflow YAML パース確認
- [ ] develop マージ後、PR #290 で `pr-ready-for-ai-review` workflow_dispatch → Definition Run Harness 起動を確認
- [ ] Harness 完了後、Status が `Human Review` または `In Progress` に遷移することを確認