### PR TITLE
fix: resolve Review Definition from PR head for auto AI Review

### DIFF
--- a/.github/scripts/definition-run-prompt-builder.cjs
+++ b/.github/scripts/definition-run-prompt-builder.cjs
@@ -145,7 +145,7 @@ function validateRunMode(runMode, registryEntry) {
   return trimmed;
 }
 
-function validateDefinitionPath(definition, { workspace } = {}) {
+function validateDefinitionPath(definition, { workspace, allowMissingOnDisk = false } = {}) {
   ensurePresent("definition", definition);
   const trimmed = String(definition).trim();
   const normalized = trimmed.replace(/\\/g, "/").replace(/^\.\//, "");
@@ -178,6 +178,9 @@ function validateDefinitionPath(definition, { workspace } = {}) {
       exists = false;
     }
     if (!exists) {
+      if (allowMissingOnDisk) {
+        return { definition: normalized, absolutePath: absolute };
+      }
       throw new ValidationError("definition_not_found", `definition file does not exist: ${normalized}`);
     }
   }
@@ -266,17 +269,22 @@ function buildPrompt({ command, definition, run_mode, output_section, target_pr 
 function buildDefinitionRunRequest(rawInput = {}, { workspace, fsImpl } = {}) {
   const { command, registry } = validateCommand(rawInput.command);
   const runMode = validateRunMode(rawInput.run_mode, registry);
-  const { definition, absolutePath } = validateDefinitionPath(rawInput.definition, { workspace });
-  const detectedType = workspace
-    ? validateDefinitionType(absolutePath, registry.definition_type, { fsImpl })
-    : registry.definition_type;
+  const ref = String(rawInput.ref || registry.default_ref || "develop").trim();
+  const allowMissingOnDisk = Boolean(ref && ref !== String(registry.default_ref || "develop").trim());
+  const { definition, absolutePath } = validateDefinitionPath(rawInput.definition, {
+    workspace,
+    allowMissingOnDisk,
+  });
+  let detectedType = registry.definition_type;
+  if (workspace && !allowMissingOnDisk) {
+    detectedType = validateDefinitionType(absolutePath, registry.definition_type, { fsImpl });
+  }
   const requestedBy = sanitizeRequestedBy(rawInput.requested_by);
   const requestIssue = sanitizeRequestIssue(rawInput.request_issue);
   const targetPr = sanitizeTargetPr(rawInput.target_pr);
   if (registry.requires_target_pr_on_live_run && runMode === "live-run" && !targetPr) {
     throw new ValidationError("missing_target_pr", "target_pr is required for review-pr live-run.");
   }
-  const ref = String(rawInput.ref || registry.default_ref || "develop").trim();
 
   const prompt = buildPrompt({
     command,

--- a/.github/scripts/dispatch-definition-run.cjs
+++ b/.github/scripts/dispatch-definition-run.cjs
@@ -26,6 +26,7 @@ function buildClientPayload({
   requestIssue,
   requestedBy,
   workspaceRoot,
+  ref,
 }) {
   const cmd = nonEmpty(command) || "review-pr";
   const def = nonEmpty(definition);
@@ -43,6 +44,7 @@ function buildClientPayload({
       target_pr: nonEmpty(targetPr),
       request_issue: nonEmpty(requestIssue),
       requested_by: nonEmpty(requestedBy),
+      ref: nonEmpty(ref),
     },
     { workspace: nonEmpty(workspaceRoot) || process.cwd() },
   );
@@ -58,6 +60,8 @@ function buildClientPayload({
   if (issue) payload.request_issue = issue;
   const by = nonEmpty(requestedBy);
   if (by) payload.requested_by = by;
+  const branchRef = nonEmpty(ref);
+  if (branchRef) payload.ref = branchRef;
   return payload;
 }
 
@@ -76,6 +80,7 @@ async function dispatchDefinitionRun({
   requestIssue,
   requestedBy,
   workspaceRoot,
+  ref,
   token,
   dryRun,
   fetchImpl,
@@ -94,6 +99,7 @@ async function dispatchDefinitionRun({
     requestIssue,
     requestedBy,
     workspaceRoot: workspace,
+    ref,
   });
 
   if (dryRun) {
@@ -152,6 +158,7 @@ function parseCliArgs(argv) {
     targetPr: "",
     requestIssue: "",
     requestedBy: "",
+    ref: "",
     dryRun: false,
   };
   for (let i = 0; i < args.length; i += 1) {
@@ -196,6 +203,10 @@ function parseCliArgs(argv) {
       options.requestedBy = args[++i] || "";
       continue;
     }
+    if (arg === "--ref") {
+      options.ref = args[++i] || "";
+      continue;
+    }
     if (arg === "--help" || arg === "-h") {
       options.help = true;
       continue;
@@ -212,7 +223,7 @@ function printHelp() {
     --target-pr <number> \\
     [--command review-pr] [--run-mode live-run] \\
     [--request-issue <number>] [--requested-by <id>] \\
-    [--repository owner/repo] [--dry-run]
+    [--ref <git-ref>] [--repository owner/repo] [--dry-run]
 
 Dispatches repository event "${EVENT_TYPE}" to run Definition Run Harness.
 `);

--- a/.github/scripts/dispatch-review-pr-harness.cjs
+++ b/.github/scripts/dispatch-review-pr-harness.cjs
@@ -36,6 +36,87 @@ async function fetchJson(url, token, fetchImpl) {
   return response.json();
 }
 
+async function loadPullRequestFiles({ owner, repo, prNumber, token, fetchImpl }) {
+  const files = [];
+  let page = 1;
+  const send = fetchImpl || global.fetch;
+
+  for (;;) {
+    const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100&page=${page}`;
+    const response = await send(url, { headers: authHeaders(token) });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(`GitHub API failed: HTTP ${response.status} ${text}`.trim());
+    }
+    const batch = await response.json();
+    if (!Array.isArray(batch) || batch.length === 0) break;
+    files.push(...batch);
+    if (batch.length < 100) break;
+    page += 1;
+  }
+
+  return files;
+}
+
+async function resolveReviewDefinitionForPull({
+  workspaceRoot,
+  pull,
+  issueBody,
+  issueNumber,
+  definitionOverride,
+  owner,
+  repo,
+  token,
+  fetchImpl,
+}) {
+  const headRef = pull.head?.ref || "";
+  const branchInfo = resolver.parseBranchRef(headRef);
+  let reviewResolution = resolver.resolveReviewDefinition({
+    workspaceRoot,
+    prBody: pull.body || "",
+    issueBody,
+    headRef,
+    issueNumber,
+    definitionOverride,
+  });
+
+  if (reviewResolution.ok) {
+    return reviewResolution;
+  }
+
+  const shouldFallback =
+    reviewResolution.reason === "ambiguous_review_definition" ||
+    reviewResolution.reason === "review_definition_not_found" ||
+    reviewResolution.reason === "ambiguous_definition_in_text";
+
+  if (!shouldFallback) {
+    return reviewResolution;
+  }
+
+  const fromPrFiles = resolver.pickReviewDefinitionFromChangedFiles(
+    await loadPullRequestFiles({ owner, repo, prNumber: pull.number, token, fetchImpl }),
+    branchInfo,
+  );
+  if (fromPrFiles) {
+    return { ok: true, path: fromPrFiles, source: "pr_changed_files" };
+  }
+
+  const directoryCandidates = resolver.reviewDefinitionCandidatesFromDirectoryHints([
+    ...resolver.extractDefinitionDirectoryHintsFromText(pull.body || ""),
+    ...resolver.extractDefinitionDirectoryHintsFromText(issueBody),
+  ]);
+  if (branchInfo?.summary) {
+    directoryCandidates.push(`${resolver.DEFINITION_ROOT}_e2e/${branchInfo.summary}/${resolver.REVIEW_FILE_NAME}`);
+  }
+
+  const uniqueCandidates = [...new Set(directoryCandidates)];
+  if (uniqueCandidates.length === 1) {
+    return { ok: true, path: uniqueCandidates[0], source: "pr_body_directory_hint" };
+  }
+
+  return reviewResolution;
+}
+
 async function loadPullRequest({ owner, repo, prNumber, token, fetchImpl }) {
   return fetchJson(
     `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`,
@@ -138,13 +219,17 @@ async function dispatchReviewPrHarness({
   }
 
   const workspace = nonEmpty(workspaceRoot) || process.cwd();
-  const reviewResolution = resolver.resolveReviewDefinition({
+  const headRef = pull.head?.ref || "";
+  const reviewResolution = await resolveReviewDefinitionForPull({
     workspaceRoot: workspace,
-    prBody: pull.body || "",
+    pull,
     issueBody,
-    headRef: pull.head?.ref || "",
     issueNumber: relatedIssue,
     definitionOverride: definition,
+    owner: resolvedRepo.owner,
+    repo: resolvedRepo.repo,
+    token: authToken,
+    fetchImpl,
   });
 
   if (!reviewResolution.ok) {
@@ -168,7 +253,11 @@ async function dispatchReviewPrHarness({
     workspaceRoot: workspace,
     reviewDefinitionPath: reviewResolution.path,
   });
-  if (aiReviewGate.ok && aiReviewGate.required === false) {
+  const skipAiReview =
+    aiReviewGate.ok &&
+    aiReviewGate.required === false &&
+    aiReviewGate.source === "task_definition";
+  if (skipAiReview) {
     return {
       ok: true,
       skipped: true,
@@ -188,6 +277,7 @@ async function dispatchReviewPrHarness({
     requestIssue: relatedIssue ? String(relatedIssue) : "",
     requestedBy: nonEmpty(requestedBy) || nonEmpty(context) || "ai-review-auto-dispatch",
     workspaceRoot: workspace,
+    ref: headRef,
     token: authToken,
     dryRun,
     fetchImpl,
@@ -199,6 +289,7 @@ async function dispatchReviewPrHarness({
     issue_number: relatedIssue ? String(relatedIssue) : null,
     review_definition: reviewResolution.path,
     review_definition_source: reviewResolution.source,
+    harness_ref: headRef || null,
     ai_review_required: true,
     dispatch: dispatchResult,
   };

--- a/.github/scripts/dispatch-review-pr-harness.test.cjs
+++ b/.github/scripts/dispatch-review-pr-harness.test.cjs
@@ -142,4 +142,58 @@ test("dispatchReviewPrHarness: 解決成功時に definition-run を dispatch", 
   assert.equal(dispatchBody.client_payload.command, "review-pr");
   assert.equal(dispatchBody.client_payload.definition, reviewPath);
   assert.equal(dispatchBody.client_payload.target_pr, "10");
+  assert.equal(dispatchBody.client_payload.ref, "docs/task-9-sample");
+});
+
+test("dispatchReviewPrHarness: local 解決失敗時 PR files から fallback", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dispatch-auto-"));
+  write(
+    path.join(root, "prompts/definitions/reviews/sample-a/pr-review.yaml"),
+    'definition_type: "review"\n',
+  );
+  write(
+    path.join(root, "prompts/definitions/reviews/sample-b/pr-review.yaml"),
+    'definition_type: "review"\n',
+  );
+
+  let dispatchBody = null;
+  const result = await auto.dispatchReviewPrHarness({
+    owner: "o",
+    repo: "r",
+    prNumber: 290,
+    issueNumber: 289,
+    requestedBy: "test",
+    workspaceRoot: root,
+    token: "token",
+    fetchImpl: async (url, init) => {
+      if (url.includes("/pulls/290/files")) {
+        return jsonResponse([
+          { filename: "prompts/definitions/_e2e/review-fix-patterns-e2e/pr-review.yaml" },
+        ]);
+      }
+      if (url.includes("/pulls/290") && !url.includes("/files")) {
+        return jsonResponse({
+          number: 290,
+          body: "Related to #289\nTask / Review Definition: `prompts/definitions/_e2e/review-fix-patterns-e2e/`",
+          head: { ref: "docs/task-289-review-fix-patterns-e2e", repo: { full_name: "o/r" } },
+        });
+      }
+      if (url.includes("/issues/289")) {
+        return jsonResponse({ body: "" });
+      }
+      if (url.endsWith("/dispatches") && init?.method === "POST") {
+        dispatchBody = JSON.parse(init.body);
+        return { ok: true, status: 204, text: async () => "" };
+      }
+      throw new Error(`unexpected url: ${url}`);
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.review_definition_source, "pr_changed_files");
+  assert.equal(
+    result.review_definition,
+    "prompts/definitions/_e2e/review-fix-patterns-e2e/pr-review.yaml",
+  );
+  assert.equal(dispatchBody.client_payload.ref, "docs/task-289-review-fix-patterns-e2e");
 });

--- a/.github/scripts/resolve-review-definition.cjs
+++ b/.github/scripts/resolve-review-definition.cjs
@@ -46,6 +46,52 @@ function extractDefinitionPathsFromText(text) {
   return [...paths];
 }
 
+function extractDefinitionDirectoryHintsFromText(text) {
+  const hints = new Set();
+  const body = String(text || "");
+
+  for (const match of body.matchAll(/`(prompts\/definitions\/[^`\s#]+)\/?`/g)) {
+    hints.add(match[1].replace(/\/$/, ""));
+  }
+
+  for (const match of body.matchAll(/(?:Task \/ Review Definition|Review Definition)\s*:\s*`?(prompts\/definitions\/[^`\s#]+)\/?`?/gi)) {
+    hints.add(match[1].replace(/\/$/, ""));
+  }
+
+  return [...hints];
+}
+
+function reviewDefinitionCandidatesFromDirectoryHints(directoryHints) {
+  const paths = new Set();
+  for (const dir of directoryHints) {
+    const normalized = nonEmpty(dir).replace(/\\/g, "/").replace(/\/$/, "");
+    if (!normalized.startsWith(DEFINITION_ROOT)) continue;
+    paths.add(`${normalized}/${REVIEW_FILE_NAME}`);
+  }
+  return [...paths];
+}
+
+function pickReviewDefinitionFromChangedFiles(changedFiles, branchInfo) {
+  const reviewFiles = (changedFiles || [])
+    .map((entry) => (typeof entry === "string" ? entry : entry?.filename || ""))
+    .filter((filename) => filename.startsWith(DEFINITION_ROOT) && filename.endsWith(`/${REVIEW_FILE_NAME}`));
+
+  if (reviewFiles.length === 1) {
+    return reviewFiles[0];
+  }
+
+  if (branchInfo?.summary) {
+    const summaryMatches = reviewFiles.filter((filename) =>
+      filename.toLowerCase().includes(`/${branchInfo.summary}/`),
+    );
+    if (summaryMatches.length === 1) {
+      return summaryMatches[0];
+    }
+  }
+
+  return "";
+}
+
 function readFileSafe(filePath) {
   try {
     return fs.readFileSync(filePath, "utf8");
@@ -209,6 +255,10 @@ function resolveReviewDefinition({
   const fromText = [
     ...extractDefinitionPathsFromText(prBody),
     ...extractDefinitionPathsFromText(issueBody),
+    ...reviewDefinitionCandidatesFromDirectoryHints([
+      ...extractDefinitionDirectoryHintsFromText(prBody),
+      ...extractDefinitionDirectoryHintsFromText(issueBody),
+    ]),
   ];
   const validFromText = fromText.filter((candidate) => fileExists(path.join(workspace, candidate)));
   if (validFromText.length === 1) {
@@ -256,14 +306,29 @@ function resolveReviewDefinition({
     .filter((entry) => entry.score > 0)
     .sort((a, b) => b.score - a.score);
 
-  if (scored.length === 1 || (scored.length > 1 && scored[0].score > scored[1].score)) {
-    return { ok: true, path: scored[0].path, source: "scan", score: scored[0].score };
+  const strongMatches = scored.filter((entry) => entry.score >= 40);
+
+  if (
+    strongMatches.length === 1 ||
+    (strongMatches.length > 1 && strongMatches[0].score > strongMatches[1].score)
+  ) {
+    return { ok: true, path: strongMatches[0].path, source: "scan", score: strongMatches[0].score };
   }
-  if (scored.length > 1 && scored[0].score === scored[1].score) {
+  if (strongMatches.length > 1 && strongMatches[0].score === strongMatches[1].score) {
     return {
       ok: false,
       reason: "ambiguous_review_definition",
-      paths: scored.slice(0, 5).map((entry) => entry.path),
+      paths: strongMatches.slice(0, 5).map((entry) => entry.path),
+    };
+  }
+
+  if (scored.length > 0) {
+    return {
+      ok: false,
+      reason: "review_definition_not_found",
+      headRef,
+      issueNumber: resolvedIssueNumber,
+      hint: "Review Definition is not on the default branch. Resolve from PR head via changed files or explicit path.",
     };
   }
 
@@ -294,6 +359,9 @@ module.exports = {
   REVIEW_FILE_NAME,
   parseBranchRef,
   extractDefinitionPathsFromText,
+  extractDefinitionDirectoryHintsFromText,
+  reviewDefinitionCandidatesFromDirectoryHints,
+  pickReviewDefinitionFromChangedFiles,
   extractTaskDefinitionPath,
   extractAiReviewRequired,
   listReviewDefinitionFiles,

--- a/.github/scripts/resolve-review-definition.test.cjs
+++ b/.github/scripts/resolve-review-definition.test.cjs
@@ -68,3 +68,35 @@ test("resolveAiReviewRequired: false のとき required=false", () => {
   });
   assert.equal(gate.required, false);
 });
+
+test("pickReviewDefinitionFromChangedFiles: PR diff から pr-review を選ぶ", () => {
+  const path = resolver.pickReviewDefinitionFromChangedFiles(
+    [
+      { filename: "prompts/definitions/_e2e/review-fix-patterns-e2e/pr-review.yaml" },
+      { filename: "prompts/definitions/_e2e/review-fix-patterns-e2e/task.yaml" },
+    ],
+    { summary: "review-fix-patterns-e2e" },
+  );
+  assert.equal(path, "prompts/definitions/_e2e/review-fix-patterns-e2e/pr-review.yaml");
+});
+
+test("resolveReviewDefinition: develop に無い場合は weak scan で not_found", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "resolve-review-"));
+  write(
+    path.join(root, "prompts/definitions/reviews/sample-a/pr-review.yaml"),
+    'definition_type: "review"\n',
+  );
+  write(
+    path.join(root, "prompts/definitions/reviews/sample-b/pr-review.yaml"),
+    'definition_type: "review"\n',
+  );
+
+  const result = resolver.resolveReviewDefinition({
+    workspaceRoot: root,
+    headRef: "docs/task-289-review-fix-patterns-e2e",
+    issueNumber: 289,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "review_definition_not_found");
+});

--- a/.github/workflows/definition-run.yml
+++ b/.github/workflows/definition-run.yml
@@ -74,6 +74,7 @@ jobs:
           PAYLOAD_REQUEST_ISSUE: ${{ github.event.client_payload.request_issue }}
           PAYLOAD_REQUESTED_BY: ${{ github.event.client_payload.requested_by }}
           PAYLOAD_TARGET_PR: ${{ github.event.client_payload.target_pr }}
+          PAYLOAD_REF: ${{ github.event.client_payload.ref }}
           INPUT_COMMAND: ${{ inputs.command }}
           INPUT_DEFINITION: ${{ inputs.definition }}
           INPUT_RUN_MODE: ${{ inputs.run_mode }}
@@ -89,13 +90,16 @@ jobs:
           REQUEST_ISSUE="${PAYLOAD_REQUEST_ISSUE:-${INPUT_REQUEST_ISSUE:-}}"
           REQUESTED_BY="${PAYLOAD_REQUESTED_BY:-${INPUT_REQUESTED_BY:-${GITHUB_ACTOR:-}}}"
           TARGET_PR="${PAYLOAD_TARGET_PR:-${INPUT_TARGET_PR:-}}"
-          echo "decision: resolve event=${GITHUB_EVENT_NAME} command=${COMMAND} run_mode=${RUN_MODE} target_pr=${TARGET_PR:-}"
+          PAYLOAD_REF_VALUE="${PAYLOAD_REF:-}"
+          REF="${PAYLOAD_REF_VALUE:-develop}"
+          echo "decision: resolve event=${GITHUB_EVENT_NAME} command=${COMMAND} run_mode=${RUN_MODE} target_pr=${TARGET_PR:-} ref=${REF}"
           echo "command=${COMMAND}" >> "$GITHUB_OUTPUT"
           echo "definition=${DEFINITION}" >> "$GITHUB_OUTPUT"
           echo "run_mode=${RUN_MODE}" >> "$GITHUB_OUTPUT"
           echo "request_issue=${REQUEST_ISSUE}" >> "$GITHUB_OUTPUT"
           echo "requested_by=${REQUESTED_BY}" >> "$GITHUB_OUTPUT"
           echo "target_pr=${TARGET_PR}" >> "$GITHUB_OUTPUT"
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
           echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
           echo "::endgroup::"
 
@@ -108,6 +112,7 @@ jobs:
           INPUT_REQUEST_ISSUE: ${{ steps.resolve.outputs.request_issue }}
           INPUT_REQUESTED_BY: ${{ steps.resolve.outputs.requested_by }}
           INPUT_TARGET_PR: ${{ steps.resolve.outputs.target_pr }}
+          INPUT_REF: ${{ steps.resolve.outputs.ref }}
         run: |
           set -euo pipefail
           echo "::group::validate-and-build-prompt"
@@ -125,6 +130,7 @@ jobs:
             request_issue: process.env.INPUT_REQUEST_ISSUE,
             requested_by: process.env.INPUT_REQUESTED_BY,
             target_pr: process.env.INPUT_TARGET_PR,
+            ref: process.env.INPUT_REF,
           };
 
           try {

--- a/docs/06_実装設計/github_actions/AI Review自動起動ワークフロー連携仕様書.md
+++ b/docs/06_実装設計/github_actions/AI Review自動起動ワークフロー連携仕様書.md
@@ -36,10 +36,12 @@ PR open / fix-ready (ready_for_ai_review)
 ## 4. Review Definition 解決順
 
 1. CLI `--definition` 明示指定
-2. PR / Issue 本文の `/review-pr @path` または `Review Definition:` 行
-3. Branch summary から `prompts/definitions/_e2e/{summary}/pr-review.yaml`
+2. PR / Issue 本文の `/review-pr @path` または `Review Definition:` / ディレクトリヒント行
+3. Branch summary から `prompts/definitions/_e2e/{summary}/pr-review.yaml`（**develop 上に存在する場合**）
 4. Task Definition と同ディレクトリの `pr-review.yaml`
-5. 全 `pr-review.yaml` スキャン（Issue 番号 / task_definition リンク / summary 一致でスコアリング）
+5. 全 `pr-review.yaml` スキャン（Issue 番号 / task_definition リンク / summary 一致でスコアリング。**score ≥ 40 のみ採用**）
+6. **fallback:** PR changed files API から `prompts/definitions/**/pr-review.yaml` を抽出（develop 未マージの Definition 向け）
+7. fallback 時は Harness dispatch に **PR head ref** を渡し、Cursor Agent が PR Branch を clone する
 
 解決不能・曖昧な場合は dispatch ステップが **失敗** し、Job Summary / Actions log に recovery コマンドを残す。
 


### PR DESCRIPTION
## Summary

- PR #291 マージ後の `ambiguous_review_definition` を修正
- develop 上に無い Review Definition（例: PR #290 の `_e2e/.../pr-review.yaml`）を **PR changed files API** から解決
- Definition Run Harness dispatch に **PR head ref** を渡し、Cursor Agent が PR Branch を clone する
- develop 上の weak scan（score=1 の同点候補）では ambiguous にせず fallback へ回す

## Root cause

`pr-ready-for-ai-review` workflow は develop を checkout するため、PR Branch 限定の Definition が見えず、`reviews/*/pr-review.yaml` が同点 ambiguous になっていた。

## Test plan

- [x] `node --test .github/scripts/resolve-review-definition.test.cjs .github/scripts/dispatch-review-pr-harness.test.cjs`
- [ ] develop マージ後、`PR Ready For AI Review Status Sync` を PR #290 で workflow_dispatch 再実行
- [ ] `Definition Run Harness`（ref=`docs/task-289-review-fix-patterns-e2e`）起動を確認