### PR TITLE
fix: post-verify ignores stale AI Review comments before harness start

### DIFF
--- a/.github/scripts/definition-run-post-verify.cjs
+++ b/.github/scripts/definition-run-post-verify.cjs
@@ -172,6 +172,7 @@ async function runReviewPrDispatchVerify({
   repo,
   targetPr,
   token,
+  startedAt,
   fetchImpl,
   verifyImpl,
 }) {
@@ -187,9 +188,10 @@ async function runReviewPrDispatchVerify({
         repo,
         prNumber: targetPr,
         token,
+        sinceIso: startedAt,
         fetchImpl,
       }));
-  return verify({ owner, repo, prNumber: targetPr, token, fetchImpl });
+  return verify({ owner, repo, prNumber: targetPr, token, sinceIso: startedAt, fetchImpl });
 }
 
 function describeBranchViolation(branch, runActor) {
@@ -260,6 +262,7 @@ async function runPostVerify({
       repo,
       targetPr,
       token,
+      startedAt,
       fetchImpl,
       verifyImpl,
     });

--- a/.github/scripts/publish-ai-review-and-dispatch.cjs
+++ b/.github/scripts/publish-ai-review-and-dispatch.cjs
@@ -212,11 +212,19 @@ async function listStatusSyncDispatchRuns({ owner, repo, token, fetchImpl, perPa
   return data.workflow_runs || [];
 }
 
-function findLatestAiReviewComment(comments) {
+function findLatestAiReviewComment(comments, { sinceIso } = {}) {
+  const since = sinceIso ? new Date(sinceIso).getTime() : NaN;
   const sorted = [...(comments || [])].sort(
     (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
   );
-  return sorted.find((comment) => slack.isAiReviewResultComment(comment.body || ""));
+  return sorted.find((comment) => {
+    if (!slack.isAiReviewResultComment(comment.body || "")) return false;
+    if (!Number.isNaN(since)) {
+      const created = new Date(comment.created_at).getTime();
+      if (Number.isNaN(created) || created < since) return false;
+    }
+    return true;
+  });
 }
 
 function findDispatchRunAfterComment({ runs, prNumber, sinceIso }) {
@@ -238,6 +246,7 @@ async function verifyAiReviewDispatch({
   repository,
   prNumber,
   token,
+  sinceIso,
   fetchImpl,
   listComments = listIssueComments,
   listRuns = listStatusSyncDispatchRuns,
@@ -255,12 +264,14 @@ async function verifyAiReviewDispatch({
     token: authToken,
     fetchImpl,
   });
-  const latestAiComment = findLatestAiReviewComment(comments);
+  const latestAiComment = findLatestAiReviewComment(comments, { sinceIso });
   if (!latestAiComment) {
     return {
       ok: false,
-      reason: "no_ai_review_comment",
-      message: "No AI Review comment found on PR.",
+      reason: sinceIso ? "no_ai_review_comment_since_run" : "no_ai_review_comment",
+      message: sinceIso
+        ? "No AI Review comment found on PR since harness started."
+        : "No AI Review comment found on PR.",
     };
   }
 

--- a/.github/scripts/publish-ai-review-and-dispatch.test.cjs
+++ b/.github/scripts/publish-ai-review-and-dispatch.test.cjs
@@ -168,3 +168,48 @@ test("verifyAiReviewDispatch: AI Reviewコメントなし", async () => {
   assert.equal(result.ok, false);
   assert.equal(result.reason, "no_ai_review_comment");
 });
+
+test("verifyAiReviewDispatch: sinceIso より前のコメントは無視する", async () => {
+  const result = await publish.verifyAiReviewDispatch({
+    repository: "o/r",
+    prNumber: 10,
+    token: "t",
+    sinceIso: "2026-05-30T12:00:00Z",
+    listComments: async () => [
+      {
+        body: SAMPLE_COMMENT,
+        created_at: "2026-05-30T00:00:00Z",
+        html_url: "https://example.com/c/old",
+      },
+    ],
+    listRuns: async () => [
+      {
+        id: 99,
+        display_title: "status-sync · dispatch · PR #10 · approve_for_human_review",
+        created_at: "2026-05-30T00:00:05Z",
+        status: "completed",
+        conclusion: "success",
+        html_url: "https://example.com/run/99",
+      },
+    ],
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "no_ai_review_comment_since_run");
+});
+
+test("findLatestAiReviewComment: sinceIso 以降の最新を返す", () => {
+  const comments = [
+    {
+      body: SAMPLE_COMMENT,
+      created_at: "2026-05-30T00:00:00Z",
+    },
+    {
+      body: SAMPLE_COMMENT.replace("approve_for_human_review", "request_changes"),
+      created_at: "2026-05-30T13:00:00Z",
+    },
+  ];
+  const latest = publish.findLatestAiReviewComment(comments, {
+    sinceIso: "2026-05-30T12:00:00Z",
+  });
+  assert.equal(latest.created_at, "2026-05-30T13:00:00Z");
+});


### PR DESCRIPTION
## Summary

- Definition Run Harness の post-verify が、**過去サイクルの AI Review コメント**を「publish 済み」と誤判定していた問題を修正
- `verifyAiReviewDispatch` に `sinceIso`（Harness 開始時刻）を渡し、その時刻以降の AI Review コメントのみを検証対象にする

## Root cause

PR #290 Phase A-1 再 AI Review 時、Cloud Agent が `GH_BOT_TOKEN` なしで publish できず Status が更新されなかったが、post-verify は Phase 0 の古い AI Review コメント + dispatch を見て `violations=0` となり Workflow が success 扱いになっていた。

## Test plan

- [x] `node --test .github/scripts/publish-ai-review-and-dispatch.test.cjs .github/scripts/definition-run-post-verify.test.cjs`
- [ ] develop マージ後、Harness live-run で publish 漏れ時に post-verify が fail することを確認