### PR TITLE
fix: Harness bot fallback for publish-ai-review-and-dispatch

### DIFF
--- a/.github/scripts/publish-ai-review-harness-fallback.cjs
+++ b/.github/scripts/publish-ai-review-harness-fallback.cjs
@@ -1,0 +1,227 @@
+"use strict";
+
+const fs = require("fs");
+const slack = require("./slack-notify.cjs");
+const publish = require("./publish-ai-review-and-dispatch.cjs");
+
+const LOG_LINE_PREFIX_RE = /^\d{4}-\d{2}-\d{2}T[^\s]+\s+/;
+const TRANSCRIPT_STOP_RE = /^---$|^### \d+\./;
+
+function nonEmpty(value) {
+  return String(value || "").trim();
+}
+
+function stripLogPrefix(line) {
+  return String(line || "").replace(LOG_LINE_PREFIX_RE, "");
+}
+
+function extractAiReviewCommentBlocks(transcript) {
+  const lines = String(transcript || "").split(/\r?\n/);
+  const stripped = lines.map(stripLogPrefix);
+  const blocks = [];
+
+  for (let idx = 0; idx < stripped.length; idx += 1) {
+    if (stripped[idx].trim() !== "# AI Review Result") continue;
+
+    const block = [];
+    for (let i = idx; i < stripped.length; i += 1) {
+      const line = stripped[i];
+      if (
+        i > idx &&
+        (TRANSCRIPT_STOP_RE.test(line.trim()) ||
+          line.includes("publish-ai-review-and-dispatch.cjs") ||
+          line.includes("publish-ai-review-harness-fallback.cjs"))
+      ) {
+        break;
+      }
+      block.push(line);
+    }
+
+    const body = block.join("\n").trim();
+    if (slack.isAiReviewResultComment(body)) {
+      blocks.push(body);
+    }
+  }
+
+  return blocks;
+}
+
+function extractLatestAiReviewCommentFromTranscript(transcript) {
+  const blocks = extractAiReviewCommentBlocks(transcript);
+  return blocks.length ? blocks[blocks.length - 1] : "";
+}
+
+async function publishAiReviewHarnessFallback({
+  owner,
+  repo,
+  repository,
+  prNumber,
+  transcriptPath,
+  transcriptText,
+  sinceIso,
+  token,
+  dryRun,
+  fetchImpl,
+}) {
+  const resolvedRepo = repository
+    ? { owner: repository.split("/")[0], repo: repository.split("/")[1] }
+    : { owner, repo };
+  const authToken = nonEmpty(token) || nonEmpty(process.env.GH_BOT_TOKEN);
+  if (!authToken) {
+    throw new Error("GH_BOT_TOKEN is required for harness publish fallback");
+  }
+  if (!prNumber) {
+    throw new Error("prNumber is required");
+  }
+
+  const verify = await publish.verifyAiReviewDispatch({
+    owner: resolvedRepo.owner,
+    repo: resolvedRepo.repo,
+    prNumber,
+    sinceIso,
+    token: authToken,
+    fetchImpl,
+  });
+  if (verify.ok) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: "already_published",
+      verify,
+    };
+  }
+
+  const transcript =
+    nonEmpty(transcriptText) ||
+    (transcriptPath && fs.existsSync(transcriptPath)
+      ? fs.readFileSync(transcriptPath, "utf8")
+      : "");
+  if (!transcript) {
+    return {
+      ok: false,
+      reason: "transcript_missing",
+      message: "Transcript is empty; cannot extract AI Review comment.",
+      prior_verify: verify,
+    };
+  }
+
+  const commentBody = extractLatestAiReviewCommentFromTranscript(transcript);
+  if (!commentBody) {
+    return {
+      ok: false,
+      reason: "no_comment_in_transcript",
+      message: "No valid AI Review comment block found in harness transcript.",
+      prior_verify: verify,
+    };
+  }
+
+  const publishResult = await publish.publishAiReviewAndDispatch({
+    owner: resolvedRepo.owner,
+    repo: resolvedRepo.repo,
+    prNumber,
+    commentBody,
+    token: authToken,
+    dryRun,
+    fetchImpl,
+  });
+
+  return {
+    ok: true,
+    skipped: false,
+    reason: "published",
+    prior_verify: verify,
+    publish: publishResult,
+  };
+}
+
+function parseCliArgs(argv) {
+  const args = argv.slice(2);
+  const options = {
+    owner: "",
+    repo: "",
+    repository: "",
+    prNumber: "",
+    transcriptPath: "",
+    sinceIso: "",
+    dryRun: false,
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--repository" || arg === "-R") {
+      options.repository = args[++i] || "";
+      continue;
+    }
+    if (arg === "--owner") {
+      options.owner = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = args[++i] || "";
+      continue;
+    }
+    if (arg === "--pr" || arg === "--pr-number") {
+      options.prNumber = args[++i] || "";
+      continue;
+    }
+    if (arg === "--transcript") {
+      options.transcriptPath = args[++i] || "";
+      continue;
+    }
+    if (arg === "--since" || arg === "--since-iso") {
+      options.sinceIso = args[++i] || "";
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node .github/scripts/publish-ai-review-harness-fallback.cjs \\
+    --repository owner/repo \\
+    --pr <number> \\
+    --transcript /path/to/definition-run-transcript.log \\
+    [--since <harness-started-at-iso>] \\
+    [--dry-run]
+
+Publishes AI Review comment + status-sync when Cloud Agent cannot use GH_BOT_TOKEN.
+`);
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv);
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  if (!options.prNumber) {
+    throw new Error("--pr is required");
+  }
+
+  const result = await publishAiReviewHarnessFallback(options);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!result.ok) process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  LOG_LINE_PREFIX_RE,
+  extractAiReviewCommentBlocks,
+  extractLatestAiReviewCommentFromTranscript,
+  publishAiReviewHarnessFallback,
+};

--- a/.github/scripts/publish-ai-review-harness-fallback.test.cjs
+++ b/.github/scripts/publish-ai-review-harness-fallback.test.cjs
@@ -1,0 +1,119 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fallback = require("./publish-ai-review-harness-fallback.cjs");
+
+const SAMPLE_COMMENT = `# AI Review Result
+
+## 1. レビュー結果
+
+| 項目          | 内容                       |
+| ------------- | -------------------------- |
+| Review Result | \`approve_for_human_review\` |
+| 対象PR        | \`#290\`                   |
+
+## 22. Status更新意図
+
+| 次Status   | \`Human Review\` |
+`;
+
+test("extractLatestAiReviewCommentFromTranscript: ログ prefix を除去して抽出", () => {
+  const transcript = [
+    "2026-05-31T15:30:00.3370233Z # AI Review Result",
+    "2026-05-31T15:30:00.4419814Z | Review Result | `approve_for_human_review` |",
+    "2026-05-31T15:30:00.8875036Z ## 22. Status更新意図",
+    "2026-05-31T15:30:01.0707915Z ---",
+  ].join("\n");
+  const body = fallback.extractLatestAiReviewCommentFromTranscript(transcript);
+  assert.match(body, /# AI Review Result/);
+  assert.match(body, /approve_for_human_review/);
+});
+
+test("extractAiReviewCommentBlocks: 複数ブロックは最後を採用", () => {
+  const transcript = `${SAMPLE_COMMENT.replace("approve_for_human_review", "request_changes")}\n---\n${SAMPLE_COMMENT}`;
+  const blocks = fallback.extractAiReviewCommentBlocks(transcript);
+  assert.equal(blocks.length, 2);
+  assert.equal(
+    fallback.extractLatestAiReviewCommentFromTranscript(transcript),
+    blocks[1],
+  );
+});
+
+test("publishAiReviewHarnessFallback: verify 済みなら skip", async () => {
+  const result = await fallback.publishAiReviewHarnessFallback({
+    repository: "o/r",
+    prNumber: 290,
+    sinceIso: "2026-05-31T15:27:52Z",
+    token: "bot-token",
+    transcriptText: SAMPLE_COMMENT,
+    fetchImpl: async (url) => {
+      if (url.includes("/issues/290/comments")) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              body: SAMPLE_COMMENT,
+              created_at: "2026-05-31T15:30:10Z",
+              html_url: "https://example.com/c/1",
+            },
+          ],
+        };
+      }
+      if (url.includes("/actions/workflows/pr-review-status-sync.yml/runs")) {
+        return {
+          ok: true,
+          json: async () => ({
+            workflow_runs: [
+              {
+                id: 1,
+                display_title: "status-sync · dispatch · PR #290 · approve_for_human_review",
+                created_at: "2026-05-31T15:30:15Z",
+                status: "completed",
+                conclusion: "success",
+              },
+            ],
+          }),
+        };
+      }
+      throw new Error(url);
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.equal(result.reason, "already_published");
+});
+
+test("publishAiReviewHarnessFallback: transcript から publish する", async () => {
+  const calls = [];
+  const result = await fallback.publishAiReviewHarnessFallback({
+    repository: "o/r",
+    prNumber: 290,
+    sinceIso: "2026-05-31T15:27:52Z",
+    token: "bot-token",
+    transcriptText: `2026-05-31T15:30:00Z ${SAMPLE_COMMENT.split("\n").join("\n2026-05-31T15:30:00Z ")}`,
+    fetchImpl: async (url, options) => {
+      calls.push({ url, method: options && options.method });
+      if (url.includes("/issues/290/comments") && (!options || !options.method || options.method === "GET")) {
+        return { ok: true, json: async () => [] };
+      }
+      if (url.includes("/issues/290/comments") && options.method === "POST") {
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({ html_url: "https://example.com/c/2", id: 2 }),
+        };
+      }
+      if (url.includes("/dispatches")) {
+        return { ok: true, status: 204, text: async () => "" };
+      }
+      if (url.includes("/actions/workflows/pr-review-status-sync.yml/runs")) {
+        return { ok: true, json: async () => ({ workflow_runs: [] }) };
+      }
+      throw new Error(url);
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.reason, "published");
+  assert.equal(calls.filter((c) => c.method === "POST").length, 2);
+});

--- a/.github/workflows/definition-run.yml
+++ b/.github/workflows/definition-run.yml
@@ -340,6 +340,26 @@ jobs:
           EOF
           echo "::endgroup::"
 
+      - name: Publish AI Review (bot fallback)
+        if: success() && steps.resolve.outputs.command == 'review-pr' && steps.resolve.outputs.run_mode == 'live-run'
+        env:
+          GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          TARGET_PR: ${{ steps.resolve.outputs.target_pr }}
+          STARTED_AT: ${{ steps.resolve.outputs.started_at }}
+        run: |
+          set -euo pipefail
+          echo "::group::publish-ai-review-bot-fallback"
+          if [ -z "${GH_BOT_TOKEN:-}" ]; then
+            echo "::error::missing_gh_bot_token secret is required for review-pr live-run publish fallback"
+            exit 1
+          fi
+          node .github/scripts/publish-ai-review-harness-fallback.cjs \
+            --repository "${{ github.repository }}" \
+            --pr "${TARGET_PR}" \
+            --transcript "${RUNNER_TEMP}/definition-run-transcript.log" \
+            --since "${STARTED_AT}"
+          echo "::endgroup::"
+
       - name: Post-run verification
         if: always()
         id: postverify

--- a/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
@@ -70,8 +70,9 @@ on:
 2. 入力検証 (Command レジストリ参照 / definition パス prefix / 実ファイル存在 / definition_type 整合 / run_mode==dry-run)
 3. プロンプト組み立て (builder スクリプト呼び出し、secret マスク)
 4. Cursor SDK で Cloud Agent 起動 (Agent.create + agent.send + cloud: { repos: [{ url, startingRef }] }, autoCreatePR: false)
-5. post-run 検証 (Issue / PR / Branch 新規作成監視 → 違反検知時は job 失敗)
-6. Job Summary 出力 ($GITHUB_STEP_SUMMARY、secret スキャナ通過後)
+5. **review-pr live-run のみ:** transcript から AI Review コメントを抽出し `GH_BOT_TOKEN` で `publish-ai-review-and-dispatch.cjs` を実行（bot fallback）
+6. post-run 検証 (Issue / PR / Branch 新規作成監視 → 違反検知時は job 失敗)
+7. Job Summary 出力 ($GITHUB_STEP_SUMMARY、secret スキャナ通過後)
 ```
 
 各ステップは `::group::<step-name>` で折り畳み、冒頭に「決定的な1行」を出力する（例: `decision: validated allowed_command=start-epic`）。
@@ -84,6 +85,7 @@ on:
 | permissions | `issues: read` | post-verify で Issue 一覧取得 |
 | permissions | `pull-requests: read` | post-verify で PR 一覧取得 |
 | Secret | `CURSOR_API_KEY` | Cursor SDK の認証。workflow env のみで使用、プロンプト・log・Summary には絶対に出さない |
+| Secret | `GH_BOT_TOKEN` | **`review-pr` + `live-run` 時**の `publish-ai-review-and-dispatch.cjs` bot fallback（Cloud Agent は PR コメント POST 不可） |
 | Token | `GITHUB_TOKEN` | post-verify で gh API を叩く（read のみ。write 全廃） |
 | permissions | `actions: read` | review-pr post-verify で workflow runs 参照 |
 


### PR DESCRIPTION
## Summary

- PR #293 の post-verify（Harness 開始以降の AI Review コメント必須）に合わせ、Cloud Agent が 403 で publish できない問題を解消
- `review-pr` live-run 完了後、transcript から AI Review コメントを抽出し `GH_BOT_TOKEN` で `publish-ai-review-and-dispatch.cjs` を実行

## Root cause (run 26716657512)

1. Cloud Agent: `publish-ai-review-and-dispatch.cjs` → HTTP 403（integration token）
2. post-verify: `no_ai_review_comment_since_run` → violations=1（**正しい検知**）
3. 手動 bot publish 後に Status は `Human Review` になったが Harness job は failure のまま

## Prerequisites

- Repository secret `GH_BOT_TOKEN`（machine account PAT）が Actions に設定されていること

## Test plan

- [x] `node --test .github/scripts/publish-ai-review-harness-fallback.test.cjs`
- [ ] develop マージ後、PR #290 で fix-ready → Harness 再実行し post-verify PASS を確認