### PR TITLE
fix: infra PR harness skip and fix-ready recovery docs

### DIFF
--- a/.github/scripts/dispatch-review-pr-harness.cjs
+++ b/.github/scripts/dispatch-review-pr-harness.cjs
@@ -144,6 +144,77 @@ function shouldSkipForContext({ context, fixOutcome }) {
   return { skip: false };
 }
 
+const HARNESS_AUTO_DISPATCH_CONTEXTS = Object.freeze(["pr-created", "fix-ready"]);
+
+const INFRA_HARNESS_SKIP_LABELS = Object.freeze([
+  "type: infra",
+  "type:infra",
+  "area: infra",
+  "area:infra",
+]);
+
+const AUTOMATION_ONLY_CHANGED_FILE_PREFIXES = Object.freeze([".github/"]);
+
+function normalizeLabelNames(labels) {
+  return (labels || []).map((item) => String(item.name || item).trim().toLowerCase()).filter(Boolean);
+}
+
+function hasInfraHarnessSkipLabel(labels) {
+  const names = normalizeLabelNames(labels);
+  return names.some((name) => INFRA_HARNESS_SKIP_LABELS.includes(name));
+}
+
+function changedFilesAreAutomationOnly(files) {
+  const paths = (files || [])
+    .map((item) => String(item.filename || item.path || item).trim())
+    .filter(Boolean);
+  if (!paths.length) return false;
+  return paths.every((filePath) =>
+    AUTOMATION_ONLY_CHANGED_FILE_PREFIXES.some((prefix) => filePath.startsWith(prefix)),
+  );
+}
+
+function isHarnessAutoDispatchContext(context) {
+  return HARNESS_AUTO_DISPATCH_CONTEXTS.includes(nonEmpty(context));
+}
+
+function shouldSkipHarnessAutoDispatch({ context, pullLabels, issueLabels, changedFiles }) {
+  if (!isHarnessAutoDispatchContext(context)) {
+    return { skip: false };
+  }
+
+  if (hasInfraHarnessSkipLabel(pullLabels) || hasInfraHarnessSkipLabel(issueLabels)) {
+    return { skip: true, reason: "infra_pr" };
+  }
+
+  if (changedFilesAreAutomationOnly(changedFiles)) {
+    return { skip: true, reason: "automation_only_changes" };
+  }
+
+  return { skip: false };
+}
+
+function buildHarnessDirectRecoveryCommand({
+  owner,
+  repo,
+  prNumber,
+  definition,
+  issueNumber,
+  headRef,
+}) {
+  const parts = [
+    "gh workflow run \"Definition Run Harness\"",
+    `-f command=review-pr`,
+    `-f definition=${definition || "prompts/definitions/<path>/pr-review.yaml"}`,
+    "-f run_mode=live-run",
+    `-f target_pr=${prNumber}`,
+  ];
+  if (issueNumber) parts.push(`-f request_issue=${issueNumber}`);
+  if (headRef) parts.push(`-f ref=${headRef}`);
+  parts.push(`--repo ${owner}/${repo}`);
+  return parts.join(" \\\n  ");
+}
+
 function buildRecoveryCommand({ owner, repo, prNumber, definition, issueNumber, requestedBy }) {
   const parts = [
     "node .github/scripts/dispatch-review-pr-harness.cjs",
@@ -207,6 +278,7 @@ async function dispatchReviewPrHarness({
     null;
 
   let issueBody = "";
+  let issueLabels = [];
   if (relatedIssue) {
     const issue = await loadIssue({
       owner: resolvedRepo.owner,
@@ -216,6 +288,45 @@ async function dispatchReviewPrHarness({
       fetchImpl,
     });
     issueBody = issue.body || "";
+    issueLabels = issue.labels || [];
+  }
+
+  let pullLabels = pull.labels || [];
+  let changedFiles = [];
+  if (isHarnessAutoDispatchContext(context)) {
+    if (!pullLabels.length) {
+      const pullIssue = await loadIssue({
+        owner: resolvedRepo.owner,
+        repo: resolvedRepo.repo,
+        issueNumber: pr,
+        token: authToken,
+        fetchImpl,
+      });
+      pullLabels = pullIssue.labels || [];
+    }
+    changedFiles = await loadPullRequestFiles({
+      owner: resolvedRepo.owner,
+      repo: resolvedRepo.repo,
+      prNumber: pr,
+      token: authToken,
+      fetchImpl,
+    });
+  }
+
+  const infraSkip = shouldSkipHarnessAutoDispatch({
+    context,
+    pullLabels,
+    issueLabels,
+    changedFiles,
+  });
+  if (infraSkip.skip) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: infraSkip.reason,
+      pr_number: String(pr),
+      issue_number: relatedIssue ? String(relatedIssue) : null,
+    };
   }
 
   const workspace = nonEmpty(workspaceRoot) || process.cwd();
@@ -410,7 +521,15 @@ if (require.main === module) {
 }
 
 module.exports = {
-  dispatchReviewPrHarness,
-  shouldSkipForContext,
+  AUTOMATION_ONLY_CHANGED_FILE_PREFIXES,
+  HARNESS_AUTO_DISPATCH_CONTEXTS,
+  INFRA_HARNESS_SKIP_LABELS,
+  buildHarnessDirectRecoveryCommand,
   buildRecoveryCommand,
+  changedFilesAreAutomationOnly,
+  dispatchReviewPrHarness,
+  hasInfraHarnessSkipLabel,
+  isHarnessAutoDispatchContext,
+  shouldSkipForContext,
+  shouldSkipHarnessAutoDispatch,
 };

--- a/.github/scripts/dispatch-review-pr-harness.test.cjs
+++ b/.github/scripts/dispatch-review-pr-harness.test.cjs
@@ -197,3 +197,89 @@ test("dispatchReviewPrHarness: local 解決失敗時 PR files から fallback", 
   );
   assert.equal(dispatchBody.client_payload.ref, "docs/task-289-review-fix-patterns-e2e");
 });
+
+test("shouldSkipHarnessAutoDispatch: type: infra ラベルで skip", () => {
+  const result = auto.shouldSkipHarnessAutoDispatch({
+    context: "pr-created",
+    pullLabels: [{ name: "type: infra" }],
+    issueLabels: [],
+    changedFiles: [{ filename: "apps/web/foo.ts" }],
+  });
+  assert.equal(result.skip, true);
+  assert.equal(result.reason, "infra_pr");
+});
+
+test("shouldSkipHarnessAutoDispatch: .github/ のみ変更で skip", () => {
+  const result = auto.shouldSkipHarnessAutoDispatch({
+    context: "fix-ready",
+    pullLabels: [],
+    issueLabels: [],
+    changedFiles: [{ filename: ".github/scripts/foo.cjs" }],
+  });
+  assert.equal(result.skip, true);
+  assert.equal(result.reason, "automation_only_changes");
+});
+
+test("shouldSkipHarnessAutoDispatch: 手動 CLI（context なし）は skip しない", () => {
+  const result = auto.shouldSkipHarnessAutoDispatch({
+    context: "",
+    pullLabels: [{ name: "type: infra" }],
+    issueLabels: [],
+    changedFiles: [{ filename: ".github/workflows/foo.yml" }],
+  });
+  assert.equal(result.skip, false);
+});
+
+test("dispatchReviewPrHarness: automation_only_changes は skipped", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "dispatch-auto-"));
+  const reviewPath = "prompts/definitions/_e2e/sample/pr-review.yaml";
+  write(path.join(root, reviewPath), 'definition_type: "review"\n');
+
+  const result = await auto.dispatchReviewPrHarness({
+    owner: "o",
+    repo: "r",
+    prNumber: 297,
+    issueNumber: 289,
+    definition: reviewPath,
+    context: "pr-created",
+    workspaceRoot: root,
+    token: "token",
+    fetchImpl: async (url) => {
+      if (url.includes("/pulls/297/files")) {
+        return jsonResponse([{ filename: ".github/scripts/dispatch-review-pr-harness.cjs" }]);
+      }
+      if (url.includes("/pulls/297")) {
+        return jsonResponse({
+          body: "Related to #289",
+          head: { ref: "fix/harness", repo: { full_name: "o/r" } },
+          labels: [],
+        });
+      }
+      if (url.includes("/issues/289")) {
+        return jsonResponse({ body: "", labels: [{ name: "type: docs" }] });
+      }
+      if (url.includes("/issues/297")) {
+        return jsonResponse({ body: "Related to #289", labels: [] });
+      }
+      throw new Error(`unexpected url: ${url}`);
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.equal(result.reason, "automation_only_changes");
+});
+
+test("buildHarnessDirectRecoveryCommand: workflow_dispatch コマンドを生成", () => {
+  const cmd = auto.buildHarnessDirectRecoveryCommand({
+    owner: "o",
+    repo: "r",
+    prNumber: 290,
+    definition: "prompts/definitions/_e2e/review-fix-patterns-e2e/pr-review.yaml",
+    issueNumber: 289,
+    headRef: "docs/task-289-review-fix-patterns-e2e",
+  });
+  assert.match(cmd, /gh workflow run "Definition Run Harness"/);
+  assert.match(cmd, /target_pr=290/);
+  assert.match(cmd, /ref=docs\/task-289-review-fix-patterns-e2e/);
+});

--- a/docs/06_実装設計/github_actions/AI Review自動起動ワークフロー連携仕様書.md
+++ b/docs/06_実装設計/github_actions/AI Review自動起動ワークフロー連携仕様書.md
@@ -53,6 +53,10 @@ PR open / fix-ready (ready_for_ai_review)
 | PR from fork | 既存 Status workflow と同様 |
 | `fix_outcome` ≠ `ready_for_ai_review` | fix-ready 経路のみ |
 | Task Definition で `review.ai_review_required: false` | AI Review 省略 |
+| PR / 関連 Issue に `type: infra` または `area: infra` ラベル | インフラ PR（CI / workflow 改修）。自動 dispatch 対象外 |
+| 変更ファイルが `.github/` 配下のみ（自動 dispatch 経路） | workflow / script 改修 PR。ラベル未付与でも skip（例: PR #297） |
+
+インフラ PR では Status=`AI Review` 更新は行っても Harness 自動起動は **しない**。AI Review が必要な場合は手動で `/review-pr` または Harness `workflow_dispatch` を実行する。
 
 ## 6. 前提
 

--- a/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
@@ -339,7 +339,44 @@ Definition Run Harness が live-run で Issue を起票した後、以下の既�
 
 live-run を解禁する場合のみ、`live_run_supported: true` 化 + 権限・ref 設計 + 承認ゲート（GitHub Environments approval）+ post-verify の許容ルール更新を別 PR で行う。
 
-## 15. 動作確認手順（MVP 受入）
+## 15. review-pr live-run recovery
+
+### 15.1 fix-ready `current_status_mismatch` 後
+
+[PR再AI Review待ちStatus更新ワークフロー仕様書](./PR再AI%20Review待ちStatus更新ワークフロー仕様書.md) §5.3 を正本とする。  
+fix-ready 再実行では Harness は起動しない。**Definition Run Harness を直接 dispatch** する。
+
+```bash
+gh workflow run "Definition Run Harness" \
+  -f command=review-pr \
+  -f definition=prompts/definitions/<path>/pr-review.yaml \
+  -f run_mode=live-run \
+  -f target_pr=<PR番号> \
+  -f request_issue=<Task Issue番号> \
+  -f requested_by=harness-recovery \
+  -f ref=<PR head ref> \
+  --repo <owner>/<repo>
+```
+
+### 15.2 bot fallback / post-verify 失敗後
+
+1. Actions log で fallback 理由（`no_comment_in_transcript` 等）と post-verify violations を確認
+2. インフラ改修 PR で fallback / post-verify を修正（develop マージ）
+3. §15.1 の **Harness 直接 dispatch** で再実行（`ref` に PR head ref を必ず指定）
+
+### 15.3 手動 CLI（`--context` なし）
+
+```bash
+node .github/scripts/dispatch-review-pr-harness.cjs \
+  --repository <owner>/<repo> \
+  --pr <PR番号> \
+  --issue <Task Issue番号> \
+  --definition prompts/definitions/<path>/pr-review.yaml
+```
+
+`--context pr-created|fix-ready` を付けない限り、インフラ PR skip（§ [AI Review自動起動](./AI%20Review自動起動ワークフロー連携仕様書.md) §5）は適用されない。
+
+## 16. 動作確認手順（MVP 受入）
 
 1. `secrets.CURSOR_API_KEY` を設定
 2. Actions UI から `workflow_dispatch` で次を実行
@@ -356,7 +393,7 @@ live-run を解禁する場合のみ、`live_run_supported: true` 化 + 権限�
 10. post-run 検証の発火確認: dry-run プロンプトを意図的に外して試験 Issue を作る再現テストで、Guard Violations に検出され job が失敗すること（受入時に手動で1回）
 11. `CURSOR_API_KEY` や類似 secret が Job Summary / Actions log に出ていないこと
 
-## 16. 関連ドキュメント
+## 17. 関連ドキュメント
 
 | ドキュメント | 役割 |
 | --- | --- |

--- a/docs/06_実装設計/github_actions/PR作成時Status更新・Slack通知ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PR作成時Status更新・Slack通知ワークフロー仕様書.md
@@ -61,6 +61,7 @@ workflow permissionsは必要最小限にする。
 | PR本文からIssue番号を解決できない | ジョブ失敗 |
 | 対象IssueがProjectに存在しない | ジョブ失敗 |
 | Slack設定不足 | Status更新は行い、Slack通知のみスキップ |
+| インフラ PR（`type: infra` 等）または `.github/` のみ変更 | Status 更新は行う。**Harness 自動起動はスキップ**（[AI Review自動起動](./AI%20Review自動起動ワークフロー連携仕様書.md) §5） |
 
 ## 7. 通知内容
 

--- a/docs/06_実装設計/github_actions/PR再AI Review待ちStatus更新ワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/PR再AI Review待ちStatus更新ワークフロー仕様書.md
@@ -57,9 +57,39 @@ on:
 | 条件 | 挙動 |
 | ---- | ---- |
 | `fix_outcome` ≠ `ready_for_ai_review` | スキップ |
-| 現在 Status が `In Progress` でない（かつ `AI Review` でもない） | スキップ（冪等・誤更新防止） |
-| 次 Status が現在 Status と同一（既に `AI Review`） | スキップ |
+| 現在 Status が `In Progress` でない（かつ `AI Review` でもない） | スキップ（冪等・誤更新防止）。**Harness dispatch も行わない** |
+| 次 Status が現在 Status と同一（既に `AI Review`） | Status 更新スキップ。**Harness dispatch は実行** |
 | PR from fork | スキップ |
+
+### 5.3 fix-ready `current_status_mismatch` 時の Harness recovery
+
+fix-ready が `current_status_mismatch` でスキップされた場合、Projects Status は `In Progress` / `AI Review` 以外（例: `Human Review`）に留まる。  
+このとき **fix-ready の再実行では Harness は起動しない**（意図した冪等ガード）。
+
+**正本 recovery:** Definition Run Harness を **直接** `workflow_dispatch` する（Status 更新は不要）。
+
+```bash
+gh workflow run "Definition Run Harness" \
+  -f command=review-pr \
+  -f definition=prompts/definitions/<path>/pr-review.yaml \
+  -f run_mode=live-run \
+  -f target_pr=<PR番号> \
+  -f request_issue=<Task Issue番号> \
+  -f requested_by=fix-ready-harness-recovery \
+  -f ref=<PR head ref> \
+  --repo <owner>/<repo>
+```
+
+| 項目 | 必須 | 備考 |
+| ---- | ---- | ---- |
+| `definition` | 必須 | 対象 PR の Review Definition パス |
+| `target_pr` | 必須 | 対象 PR 番号 |
+| `ref` | **PR Branch 限定 Definition 時は必須** | PR head ref。未指定時 `develop` 固定となり `definition_not_found` になりうる |
+| `request_issue` | 推奨 | トレース用 |
+
+代替: `node .github/scripts/dispatch-review-pr-harness.cjs` を **`--context` なし**（手動 recovery）で実行してもよい（[Definition Run Harness recovery](./Definition%20Run%20Harness%E3%83%AF%E3%83%BC%E3%82%AF%E3%83%95%E3%83%AD%E3%83%BC%E4%BB%98%E6%A7%98%E6%9B%B8.md) §15 参照）。
+
+**典型シナリオ:** Phase C-2 等で fix-ready 後に Harness が失敗し、Status が `Human Review` 等に遷移したまま fix-ready を再実行した場合（E2E run `26719313872`）。
 
 ### 5.2 ジョブ失敗
 
@@ -87,6 +117,7 @@ PR 初回作成時の「PRを作成しました」とは **文面を分離** す
 - Status が `AI Review` になったら、workflow が **Definition Run Harness**（`review-pr` / `live-run`）を自動起動する（[AI Review自動起動ワークフロー連携仕様書.md](./AI%20Review自動起動ワークフロー連携仕様書.md)）
 - `split_required` / `partial_fix` 等では dispatch **しない**（Status は `In Progress` 維持）
 - dispatch 忘れ時は `--verify` / `--dispatch-only` / `workflow_dispatch` で recovery
+- fix-ready が `current_status_mismatch` で Harness dispatch をスキップした場合は [§5.3](./PR再AI%20Review待ちStatus更新ワークフロー仕様書.md#53-fix-ready-current_status_mismatch-時の-harness-recovery) の **Harness 直接 dispatch** を使う（fix-ready 再実行では解消しない）
 - 人間が手動修正した場合（パターン B）は Fixer CLI を実行せず、**workflow_dispatch** または手動 Status 更新 + `/review-pr`
 - Machine account PAT（`GH_BOT_TOKEN`）で PR コメント投稿・dispatch すること
 


### PR DESCRIPTION
Related to #289

## Summary
- fix-ready current_status_mismatch recovery documented as Harness direct workflow_dispatch
- Skip harness auto-dispatch for infra PRs (type: infra labels or .github/ only changes)

## Test plan
- [x] dispatch-review-pr-harness.test.cjs 10/10 pass

Made with [Cursor](https://cursor.com)