### PR TITLE
[Epic]AI Reviewコメント出力是正

### DIFF
--- a/.cursor/commands/review-pr.md
+++ b/.cursor/commands/review-pr.md
@@ -847,7 +847,9 @@ Harness 入力:
 | `run_mode` | 必須 | `dry-run` または `live-run` |
 | `target_pr` | live-run 時必須 | 対象 PR 番号 |
 
-live-run 完了後、Harness post-run 検証が dispatch 忘れを検知する。違反時は Guard Violations に `review_dispatch` が列挙され、ジョブは失敗する。
+Harness live-run では Cloud Agent から GitHub へ書き込めず、Harness が **Agent の最終出力テキストから AI Review コメントを再構成して投稿**する。そのため AI Review コメント本文（[ai-review-comment.md](../../prompts/templates/review/ai-review-comment.md) の全セクション）を **省略せず逐語で出力**する。`...` 等の省略・`/tmp` 等ローカルファイルへの退避・「全文は … を参照」のような参照で本文を代替しない（本文退避は投稿スクリプトが拒否する）。
+
+live-run 完了後、Harness post-run 検証が dispatch 忘れと **コメント本文の切り詰め**を検知する。違反時は Guard Violations に `review_dispatch` / `review_comment_truncated` が列挙され、ジョブは失敗する。
 
 ---
 

--- a/.github/scripts/definition-run-post-verify.cjs
+++ b/.github/scripts/definition-run-post-verify.cjs
@@ -195,6 +195,18 @@ function describeReviewDispatchViolation({ prNumber, verifyResult }) {
   };
 }
 
+function describeReviewCommentTruncatedViolation({ prNumber, verifyResult }) {
+  return {
+    type: "review_comment_truncated",
+    number: Number(prNumber),
+    title: "ai_review_comment_truncated",
+    url: verifyResult.latest_ai_review_comment_url || "",
+    created_at: verifyResult.latest_ai_review_comment_at || "",
+    actor_login: "-",
+    actor_type: "review_comment_truncated",
+  };
+}
+
 async function runReviewPrDispatchVerify({
   owner,
   repo,
@@ -330,6 +342,11 @@ async function runPostVerify({
       violations.push(
         describeReviewDispatchViolation({ prNumber: targetPr, verifyResult: dispatchVerify }),
       );
+    } else if (dispatchVerify.ok && dispatchVerify.latest_ai_review_comment_truncated) {
+      // dispatch は成立しているが、投稿済みコメント本文が切り詰められている。
+      violations.push(
+        describeReviewCommentTruncatedViolation({ prNumber: targetPr, verifyResult: dispatchVerify }),
+      );
     }
   }
 
@@ -377,7 +394,7 @@ function formatViolationsMarkdown(result) {
     const identifier =
       violation.type === "branch"
         ? `\`${violation.name}\` (${(violation.sha || "").slice(0, 7)})`
-        : violation.type === "review_dispatch"
+        : violation.type === "review_dispatch" || violation.type === "review_comment_truncated"
           ? `PR #${violation.number} ${violation.title || ""}`.trim()
           : `#${violation.number} ${violation.title || ""}`.trim();
     const actor = `${violation.actor_login || "-"} (${violation.actor_type})`;
@@ -398,6 +415,7 @@ module.exports = {
   describeIssueViolation,
   describePullViolation,
   describeReviewDispatchViolation,
+  describeReviewCommentTruncatedViolation,
   formatViolationsMarkdown,
   listBranchesCreatedSince,
   listIssuesCreatedSince,

--- a/.github/scripts/definition-run-post-verify.test.cjs
+++ b/.github/scripts/definition-run-post-verify.test.cjs
@@ -276,6 +276,30 @@ test("runPostVerify: review-pr live-run で dispatch 済みなら violation な�
   assert.equal(result.dispatch_verify.ok, true);
 });
 
+test("runPostVerify: review-pr live-run で投稿済みコメントが切り詰めなら violation", async () => {
+  const result = await post.runPostVerify({
+    owner: "o",
+    repo: "r",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    runMode: "live-run",
+    runActor: "agent",
+    command: "review-pr",
+    targetPr: "282",
+    token: "t",
+    listIssues: async () => [],
+    listPulls: async () => [],
+    listBranches: async () => [],
+    verifyImpl: async () => ({
+      ok: true,
+      dispatch_run_id: 1,
+      latest_ai_review_comment_truncated: true,
+      latest_ai_review_comment_url: "https://example.com/c/1",
+    }),
+  });
+  assert.equal(result.counts.violations, 1);
+  assert.equal(result.violations[0].type, "review_comment_truncated");
+});
+
 test("runPostVerify: review-pr live-run は対象 PR head branch の commit 更新を違反にしない", async () => {
   const result = await post.runPostVerify({
     octokit: {},

--- a/.github/scripts/definition-run-prompt-builder.cjs
+++ b/.github/scripts/definition-run-prompt-builder.cjs
@@ -252,6 +252,11 @@ function buildPrompt({ command, definition, run_mode, output_section, target_pr 
       "Harness post-run 検証で dispatch 忘れがあるとジョブは失敗する。",
       "PR コメント本文は prompts/templates/review/ai-review-comment.md に従い、",
       "先頭に `# AI Review Result` と §1 の `| Review Result |` 行を必ず含める。",
+      "Harness では Cloud Agent から GitHub への書き込みはできず、",
+      "Harness が Agent の最終出力テキストから AI Review コメントを再構成して投稿する。",
+      "そのため AI Review コメント本文（ai-review-comment.md の全セクション）を",
+      "最終出力に省略せず逐語で出力する。`...` 等の省略、`/tmp` 等ローカルファイルへの退避、",
+      "「全文は … を参照」のような参照で本文を代替してはならない。",
       "Harness bot fallback は prose のみでは抽出できない場合がある。",
       "",
     );

--- a/.github/scripts/definition-run-prompt-builder.test.cjs
+++ b/.github/scripts/definition-run-prompt-builder.test.cjs
@@ -376,6 +376,8 @@ test("review-pr: live-run は target_pr 必須", () => {
     assert.equal(request.target_pr, "282");
     assert.match(request.prompt, /publish-ai-review-and-dispatch/);
     assert.match(request.prompt, /対象PR: #282/);
+    assert.match(request.prompt, /逐語で出力/);
+    assert.match(request.prompt, /本文を代替してはならない/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/.github/scripts/publish-ai-review-and-dispatch.cjs
+++ b/.github/scripts/publish-ai-review-and-dispatch.cjs
@@ -7,8 +7,27 @@ const dispatch = require("./dispatch-pr-review-status-sync.cjs");
 const STATUS_SYNC_WORKFLOW_FILE = "pr-review-status-sync.yml";
 const DISPATCH_RUN_TITLE_RE = /status-sync · dispatch · PR #(\d+)/;
 
+// Cloud Agent が本文を自身のサンドボックスへ退避し、コメント本文を省略・参照で
+// 代替してしまう切り詰めパターン。これらを含む本文は不完全とみなし投稿を拒否する。
+const TRUNCATION_PATTERNS = Object.freeze([
+  // ローカル一時ファイル参照（例: /tmp/ai-review-comment-302.md）
+  /(?:^|[\s`(（])\/(?:tmp|var\/folders|private\/tmp)\/[^\s`)）]+\.(?:md|markdown|txt)/i,
+  // 「全文は … を参照」のような本文退避表現
+  /全文[はを][\s\S]{0,40}参照/,
+  /(?:full\s+(?:text|body|version)|complete\s+(?:text|body))[\s\S]{0,40}(?:see|refer)/i,
+  // 省略を示す単独の三点リーダ行
+  /^\s*(?:\.{3}|…|\.{3}\s*\(.*\)|…\s*\(.*\))\s*$/m,
+]);
+
 function nonEmpty(value) {
   return String(value || "").trim();
+}
+
+// AI Review コメント本文が切り詰め（本文退避・省略）されているかを判定する。
+function isTruncatedAiReviewComment(body) {
+  const text = String(body || "");
+  if (!text) return false;
+  return TRUNCATION_PATTERNS.some((pattern) => pattern.test(text));
 }
 
 function resolveRepository({ owner, repo, repository }) {
@@ -137,6 +156,12 @@ async function publishAiReviewAndDispatch({
   if (!dispatchOnly) {
     if (!slack.isAiReviewResultComment(body)) {
       throw new Error("Comment is not ai-review-comment format. Use prompts/templates/review/ai-review-comment.md.");
+    }
+    if (isTruncatedAiReviewComment(body)) {
+      throw new Error(
+        "Comment appears truncated (local file reference / omission marker). " +
+          "Post the full AI Review comment body verbatim, not a /tmp reference or summary.",
+      );
     }
     commentResult = await postPullRequestComment({
       owner: resolved.owner,
@@ -310,6 +335,7 @@ async function verifyAiReviewDispatch({
     pr_number: String(prNumber),
     latest_ai_review_comment_url: latestAiComment.html_url || "",
     latest_ai_review_comment_at: latestAiComment.created_at || "",
+    latest_ai_review_comment_truncated: isTruncatedAiReviewComment(latestAiComment.body || ""),
     dispatch_run_id: matchedRun.id,
     dispatch_run_url: matchedRun.html_url || "",
     dispatch_run_title: matchedRun.display_title || matchedRun.name || "",
@@ -438,6 +464,8 @@ if (require.main === module) {
 module.exports = {
   STATUS_SYNC_WORKFLOW_FILE,
   DISPATCH_RUN_TITLE_RE,
+  TRUNCATION_PATTERNS,
+  isTruncatedAiReviewComment,
   resolveReviewResult,
   postPullRequestComment,
   publishAiReviewAndDispatch,

--- a/.github/scripts/publish-ai-review-and-dispatch.test.cjs
+++ b/.github/scripts/publish-ai-review-and-dispatch.test.cjs
@@ -20,6 +20,77 @@ const SAMPLE_COMMENT = `# AI Review Result
 | 次Status   | \`Human Review\` |
 `;
 
+const TRUNCATED_COMMENT = `# AI Review Result
+
+## 1. レビュー結果
+
+| 項目          | 内容                       |
+| ------------- | -------------------------- |
+| Review Result | \`approve_for_human_review\` |
+| 対象PR        | \`302\`                    |
+...
+
+（全文は \`/tmp/ai-review-comment-302.md\` を参照）
+`;
+
+test("isTruncatedAiReviewComment: ローカルファイル参照/省略を検出する", () => {
+  assert.equal(publish.isTruncatedAiReviewComment(TRUNCATED_COMMENT), true);
+  assert.equal(publish.isTruncatedAiReviewComment(SAMPLE_COMMENT), false);
+});
+
+test("isTruncatedAiReviewComment: 全文参照表現を検出する", () => {
+  assert.equal(
+    publish.isTruncatedAiReviewComment("# AI Review Result\n全文は別ファイルを参照"),
+    true,
+  );
+});
+
+test("publishAiReviewAndDispatch: 切り詰め本文は投稿を拒否する", async () => {
+  await assert.rejects(
+    () =>
+      publish.publishAiReviewAndDispatch({
+        repository: "o/r",
+        prNumber: 10,
+        commentBody: TRUNCATED_COMMENT,
+        token: "t",
+        fetchImpl: async () => {
+          throw new Error("must not be called");
+        },
+      }),
+    (error) => {
+      assert.match(error.message, /truncated/i);
+      return true;
+    },
+  );
+});
+
+test("verifyAiReviewDispatch: 切り詰めコメントは truncated フラグを返す", async () => {
+  const result = await publish.verifyAiReviewDispatch({
+    repository: "o/r",
+    prNumber: 10,
+    token: "t",
+    listComments: async () => [
+      {
+        body: TRUNCATED_COMMENT,
+        created_at: "2026-05-30T00:00:00Z",
+        html_url: "https://example.com/c/1",
+      },
+    ],
+    listRuns: async () => [
+      {
+        id: 99,
+        display_title: "status-sync · dispatch · PR #10 · approve_for_human_review",
+        created_at: "2026-05-30T00:00:05Z",
+        status: "completed",
+        conclusion: "success",
+        html_url: "https://example.com/run/99",
+      },
+    ],
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.latest_ai_review_comment_truncated, true);
+});
+
 test("resolveReviewResult: コメントからReview Resultを抽出する", () => {
   const value = publish.resolveReviewResult({ commentBody: SAMPLE_COMMENT });
   assert.equal(value, "approve_for_human_review");

--- a/.github/scripts/publish-ai-review-harness-fallback.cjs
+++ b/.github/scripts/publish-ai-review-harness-fallback.cjs
@@ -115,7 +115,9 @@ function synthesizeAiReviewComment({ reviewResult, prNumber }) {
 
 function extractLatestAiReviewCommentFromTranscript(transcript, { prNumber } = {}) {
   const blocks = extractAiReviewCommentBlocks(transcript);
-  if (blocks.length) return blocks[blocks.length - 1];
+  // 切り詰め（本文退避・省略）ブロックは投稿せず、合成フォールバックへ回す。
+  const usableBlocks = blocks.filter((block) => !publish.isTruncatedAiReviewComment(block));
+  if (usableBlocks.length) return usableBlocks[usableBlocks.length - 1];
 
   const unique = collectUniqueReviewResults(transcript);
   if (unique.length === 1) {

--- a/.github/scripts/publish-ai-review-harness-fallback.test.cjs
+++ b/.github/scripts/publish-ai-review-harness-fallback.test.cjs
@@ -166,6 +166,37 @@ test("publishAiReviewHarnessFallback: result.json から transcript 不足を補
   assert.equal(calls.filter((c) => c.method === "POST").length, 2);
 });
 
+test("extractLatestAiReviewCommentFromTranscript: 切り詰めブロックは採用せず合成へ", () => {
+  const truncated = `# AI Review Result
+
+## 1. レビュー結果
+
+| 項目          | 内容                       |
+| ------------- | -------------------------- |
+| Review Result | \`approve_for_human_review\` |
+...
+
+（全文は \`/tmp/ai-review-comment-302.md\` を参照）`;
+  const body = fallback.extractLatestAiReviewCommentFromTranscript(truncated, { prNumber: 302 });
+  assert.doesNotMatch(body, /\/tmp\//);
+  assert.match(body, /harness-fallback: synthesized/);
+  assert.match(body, /approve_for_human_review/);
+});
+
+test("extractLatestAiReviewCommentFromTranscript: 完全ブロックがあれば切り詰めより優先", () => {
+  const truncated = `# AI Review Result
+
+## 1. レビュー結果
+
+| Review Result | \`request_changes\` |
+...
+（全文は \`/tmp/x.md\` を参照）`;
+  const transcript = `${SAMPLE_COMMENT}\n---\n${truncated}`;
+  const body = fallback.extractLatestAiReviewCommentFromTranscript(transcript);
+  assert.doesNotMatch(body, /\/tmp\//);
+  assert.match(body, /## 22\. Status更新意図/);
+});
+
 test("extractLatestAiReviewCommentFromTranscript: prose の単一トークンから合成", () => {
   const transcript = [
     "レビュー結論は approve_for_human_review です。",

--- a/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
@@ -73,8 +73,8 @@ on:
 2. 入力検証 (Command レジストリ参照 / definition パス prefix / 実ファイル存在 / definition_type 整合 / run_mode==dry-run)
 3. プロンプト組み立て (builder スクリプト呼び出し、secret マスク)
 4. Cursor SDK で Cloud Agent 起動 (Agent.create + agent.send + cloud: { repos: [{ url, startingRef }] }, autoCreatePR: false)
-5. **review-pr live-run のみ:** transcript（および Agent `run.result`）から AI Review コメントを抽出し `GH_BOT_TOKEN` で `publish-ai-review-and-dispatch.cjs` を実行（bot fallback）
-6. post-run 検証 (Issue / PR / Branch 新規作成監視 → 違反検知時は job 失敗)
+5. **review-pr live-run のみ:** transcript（および Agent `run.result`）から AI Review コメントを抽出し `GH_BOT_TOKEN` で `publish-ai-review-and-dispatch.cjs` を実行（bot fallback）。**切り詰め本文（`/tmp` 等ローカルファイル参照・「全文は … を参照」・省略マーカー）は投稿前に拒否し、抽出対象からも除外する**
+6. post-run 検証 (Issue / PR / Branch 新規作成監視、**コメント本文の切り詰め検知** → 違反検知時は job 失敗)
 7. Job Summary 出力 ($GITHUB_STEP_SUMMARY、secret スキャナ通過後)
 ```
 
@@ -371,6 +371,17 @@ gh workflow run "Definition Run Harness" \
 4. post-verify は `review-pr` 実行時に `target_pr` の head branch を違反判定から除外する
 5. インフラ改修 PR で fallback / post-verify を修正（develop マージ）
 6. §15.1 の **Harness 直接 dispatch** で再実行（`ref` に PR head ref を必ず指定）
+
+### 15.2.1 AI Review コメント本文の完全性
+
+Harness live-run では Cloud Agent から GitHub へ書き込めないため、**Agent の最終出力テキストが投稿本文の元**になる。Agent が本文を自サンドボックス（`/tmp` 等）へ退避し、コメントを `（全文は /tmp/... を参照）` のような参照や `...` 省略で代替すると、Human Review に必要なレビュー観点・判定理由が GitHub コメントへ載らない。これを防ぐため以下を実装する。
+
+| レイヤ | 挙動 |
+| ------ | ---- |
+| プロンプト（`definition-run-prompt-builder.cjs`） | review-pr live-run で「コメント本文を ai-review-comment.md の全セクション分、省略せず逐語出力」「`/tmp` 退避・参照・省略での代替禁止」を指示 |
+| 投稿（`publish-ai-review-and-dispatch.cjs`） | `isTruncatedAiReviewComment` で切り詰め本文を検出し、投稿前に拒否（`TRUNCATION_PATTERNS`: ローカル一時ファイル参照 / 「全文は … を参照」/ 単独の三点リーダ行） |
+| fallback 抽出（`publish-ai-review-harness-fallback.cjs`） | transcript から抽出したブロックのうち切り詰めブロックを除外。残らない場合は synthetic comment へフォールバック |
+| post-verify（`definition-run-post-verify.cjs`） | dispatch 成立後も投稿済みコメントが切り詰めなら `review_comment_truncated` 違反として job を失敗させる |
 
 ### 15.3 手動 CLI（`--context` なし）
 


### PR DESCRIPTION
Closes #303

## 1. 概要

Definition Run Harness（`/review-pr` live-run）で AI Review コメントが切り詰められ、Cloud Agent サンドボックス内ファイル参照（例: `（全文は /tmp/ai-review-comment-302.md を参照）`）で本文が代替される事象を是正する Epic です。

| 項目 | 内容 |
| ---- | ---- |
| Epic ID | `epic-ai-review-comment-output-fix` |
| 対象Epic Issue | #303 |
| Source Branch | `fix/epic-303-ai-review-comment-output-fix` |
| Target Branch | `develop` |

## 2. 対象Issue

Closes #303

## 3. Epic Scope

| 項目 | 内容 |
| ---- | ---- |
| 対象識別子 | （なし・機能・領域単位 Epic） |
| allowed_paths | `.github/scripts/**`, `.github/workflows/definition-run.yml`, `.cursor/commands/review-pr.md`, `prompts/templates/review/**`, `docs/06_実装設計/github_actions/**` |
| forbidden_paths | `apps/**`, `openapi/**`, `packages/**`, `db/**`, `prompts/definitions/**` |

## 4. 統合したTask

| Task Issue | Task名 | PR | 状態 | 備考 |
| ---------- | ------ | -- | ---- | ---- |
| #305 | AI Reviewコメント切り詰め是正（Harness本文投稿） | #307 | merged / closed | Human Review Approve 済み |

## 5. 対応内容

- **プロンプト:** `definition-run-prompt-builder.cjs` — live-run でコメント全文の逐語出力、`/tmp` 退避・参照禁止
- **投稿前:** `publish-ai-review-and-dispatch.cjs` — `isTruncatedAiReviewComment` / `TRUNCATION_PATTERNS` で切り詰め拒否
- **fallback:** `publish-ai-review-harness-fallback.cjs` — 切り詰めブロック除外 → synthetic comment
- **事後検証:** `definition-run-post-verify.cjs` — `review_comment_truncated` 違反で job 失敗
- **docs / command:** Harness 仕様書 §15.2.1、`.cursor/commands/review-pr.md`（Definition Run 節のみ最小限）

## 6. 変更ファイル

| 区分 | ファイル |
| ---- | -------- |
| scripts / tests | `.github/scripts/*`（4 本 + 4 `*.test.cjs`） |
| docs | `docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md` |
| command | `.cursor/commands/review-pr.md` |

## 7. Epic完了条件（#303 §14）

- [x] AI Review コメント切り詰めの根本原因が特定・記録されている（PR #307 / #305）
- [x] 完全本文が GitHub コメントへ投稿される運用（プロンプト + 4 層ガード）
- [x] ローカル `/tmp` 参照で本文代替しない
- [x] 再発防止の検証（`*.test.cjs` + post-verify）
- [x] 判定 token 抽出・Status 遷移に退行なし

## 8. テスト・検証結果

### 実施済み

- [x] `node --test .github/scripts/`（クリーン env）**125 / 125 pass**
- [x] Task PR #307 Human Review Approve

### 実行コマンド

```bash
env -i HOME="$HOME" PATH="/usr/local/bin:/usr/bin:/bin" node --test .github/scripts/
```

### 未実施

- [ ] Harness `review-pr` live-run の実 PR スモーク（automation-only のため AI Review 自動 dispatch は skip し得る。Epic merge 後の任意確認として推奨）

## 9. 横断影響

| 対象 | 影響有無 | 内容 |
| ---- | -------- | ---- |
| API contract | なし | |
| DB | なし | |
| generated | なし | |
| CI/CD | あり | Definition Run Harness / AI Review 投稿・post-verify |
| security | なし | secret 混入なし |

## 10. AI Review結果

- Task PR #307: automation-only のため自動 dispatch skip は想定内。Human Review で内容確認済み。

## 11. Human Reviewで確認してほしいこと

- Epic 統合として #305/#307 の変更が scope 内に収まっているか
- `develop` 反映後の Harness 運用（切り詰めガード）の受け入れ
- Epic #300（Contract/Implementation 分離）との `review-pr.md` 競合時は、#307 の末尾追記（Definition Run 節）をマージ側で取り込む想定

## 12. 注意

- PR merge は Human 判断（本 PR 作成のみ）
