### PR TITLE
[Task]Definition Run:fix-review-comments post-verify除外とFix完了bot fallback

### DIFF
--- a/.github/scripts/definition-run-post-verify.cjs
+++ b/.github/scripts/definition-run-post-verify.cjs
@@ -5,6 +5,12 @@ const ALLOWED_AUTOMATION_ACTORS = Object.freeze([
   "github-actions",
 ]);
 
+/** live-run で target PR head への push を誤検知しない command */
+const COMMANDS_EXCLUDING_TARGET_PR_HEAD_REF = Object.freeze([
+  "review-pr",
+  "fix-review-comments",
+]);
+
 const DEFAULT_BRANCH_PROTECTED_PATTERNS = Object.freeze([
   /^refs\/heads\/main$/,
   /^refs\/heads\/develop$/,
@@ -277,7 +283,8 @@ async function runPostVerify({
   const branches = await listBranches({ octokit, owner, repo, since: startedAt });
 
   let excludedPrHeadRef = "";
-  if (String(command || "").trim() === "review-pr" && targetPr) {
+  const cmd = String(command || "").trim();
+  if (COMMANDS_EXCLUDING_TARGET_PR_HEAD_REF.includes(cmd) && targetPr) {
     excludedPrHeadRef = await resolveTargetPrHeadRef({
       octokit,
       owner,

--- a/.github/scripts/definition-run-post-verify.test.cjs
+++ b/.github/scripts/definition-run-post-verify.test.cjs
@@ -334,3 +334,39 @@ test("runPostVerify: review-pr live-run は対象 PR head branch の commit 更�
   assert.equal(result.violations[0].type, "branch");
   assert.equal(result.violations[0].name, "feature/unrelated");
 });
+
+test("runPostVerify: fix-review-comments live-run は対象 PR head branch の commit 更新を違反にしない", async () => {
+  const result = await post.runPostVerify({
+    octokit: {},
+    owner: "o",
+    repo: "r",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    runMode: "live-run",
+    runActor: "agent",
+    command: "fix-review-comments",
+    targetPr: "359",
+    token: "t",
+    getPullImpl: async () => ({
+      head: { ref: "docs/task-358-api-pub-002-recommendation-run-api-spec" },
+    }),
+    listIssues: async () => [],
+    listPulls: async () => [],
+    listBranches: async () => [
+      buildBranch({
+        name: "docs/task-358-api-pub-002-recommendation-run-api-spec",
+        login: "okuri-ai-bot",
+        committed_at: "2026-01-01T00:04:00.000Z",
+      }),
+      buildBranch({
+        name: "feature/unrelated",
+        login: "agent",
+        committed_at: "2026-01-01T00:05:00.000Z",
+      }),
+    ],
+  });
+  assert.equal(result.excluded_pr_head_ref, "docs/task-358-api-pub-002-recommendation-run-api-spec");
+  assert.equal(result.counts.branches, 1);
+  assert.equal(result.counts.violations, 1);
+  assert.equal(result.violations[0].type, "branch");
+  assert.equal(result.violations[0].name, "feature/unrelated");
+});

--- a/.github/scripts/publish-fix-complete-harness-fallback.cjs
+++ b/.github/scripts/publish-fix-complete-harness-fallback.cjs
@@ -1,0 +1,357 @@
+"use strict";
+
+const fs = require("fs");
+const slack = require("./slack-notify.cjs");
+const publish = require("./publish-fix-complete-and-dispatch.cjs");
+
+const LOG_LINE_PREFIX_RE = /^\d{4}-\d{2}-\d{2}T[^\s]+\s+/;
+const TRANSCRIPT_STOP_RE = /^---$|^### \d+\.|^## \d+\./;
+const FIX_COMPLETE_TITLE = slack.FIX_COMPLETE_TITLE;
+const FIX_COMMAND_RESULT_HEADING = "## fix-review-comments 実行結果";
+
+function nonEmpty(value) {
+  return String(value || "").trim();
+}
+
+function stripLogPrefix(line) {
+  return String(line || "").replace(LOG_LINE_PREFIX_RE, "");
+}
+
+function isValidFixCompleteCommentBody(body) {
+  return Boolean(body) && slack.isFixCompleteResultComment(body);
+}
+
+function ensureFixCompleteTitle(body) {
+  const text = String(body || "").trim();
+  if (!text) return "";
+  if (text.includes(FIX_COMPLETE_TITLE)) return text;
+  return `${FIX_COMPLETE_TITLE}\n\n${text}`;
+}
+
+function extractBlockFromStart(stripped, startIdx) {
+  const block = [];
+  for (let i = startIdx; i < stripped.length; i += 1) {
+    const line = stripped[i];
+    if (
+      i > startIdx &&
+      (TRANSCRIPT_STOP_RE.test(line.trim()) ||
+        line.includes("publish-fix-complete-and-dispatch.cjs") ||
+        line.includes("publish-fix-complete-harness-fallback.cjs"))
+    ) {
+      break;
+    }
+    block.push(line);
+  }
+  return block.join("\n").trim();
+}
+
+function extractFixCompleteCommentBlocks(transcript) {
+  const lines = String(transcript || "").split(/\r?\n/);
+  const stripped = lines.map(stripLogPrefix);
+  const blocks = [];
+  const startHeadings = [
+    FIX_COMPLETE_TITLE,
+    FIX_COMMAND_RESULT_HEADING,
+    slack.FIX_COMPLETE_HEADING_1,
+  ];
+
+  for (let idx = 0; idx < stripped.length; idx += 1) {
+    const trimmed = stripped[idx].trim();
+    if (!startHeadings.some((heading) => trimmed === heading || trimmed.startsWith(heading))) {
+      continue;
+    }
+    const body = ensureFixCompleteTitle(extractBlockFromStart(stripped, idx));
+    if (isValidFixCompleteCommentBody(body)) {
+      blocks.push(body);
+    }
+  }
+
+  return blocks;
+}
+
+function extractFixOutcomeFromProse(text) {
+  const normalized = String(text || "");
+  const sectionMatch = /###\s*Fix Outcome\s*\n+\s*`?([^\n`]+)`?/i.exec(normalized);
+  if (sectionMatch) {
+    return slack.normalizeKnownFixOutcome(sectionMatch[1]);
+  }
+  const tableOutcome = slack.extractFixOutcomeTableCell(normalized);
+  if (tableOutcome) return tableOutcome;
+
+  const found = new Set();
+  for (const item of slack.KNOWN_FIX_OUTCOMES || []) {
+    if (new RegExp(`\\b${item}\\b`).test(normalized)) {
+      found.add(item);
+    }
+  }
+  if (found.size === 1) return [...found][0];
+  return "";
+}
+
+function synthesizeFixCompleteComment({ fixOutcome, prNumber }) {
+  const outcome = slack.normalizeKnownFixOutcome(fixOutcome);
+  if (!outcome) return "";
+  const prLabel = prNumber ? `#${Number(prNumber)}` : "-";
+  const body = `${FIX_COMPLETE_TITLE}
+
+## 1. 対応結果
+
+| 項目 | 内容 |
+| ---- | ---- |
+| Fix Outcome | \`${outcome}\` |
+| 対象PR | \`${prLabel}\` |
+
+## 12. Status更新意図
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 次Status | \`AI Review\` |
+
+<!-- harness-fallback: synthesized from agent transcript -->
+`;
+  return isValidFixCompleteCommentBody(body) ? body : "";
+}
+
+function extractLatestFixCompleteCommentFromTranscript(transcript, { prNumber } = {}) {
+  const blocks = extractFixCompleteCommentBlocks(transcript);
+  const usableBlocks = blocks.filter((block) => {
+    const extracted = slack.extractFixOutcomeFromComment(block);
+    return extracted.ok;
+  });
+  if (usableBlocks.length) return usableBlocks[usableBlocks.length - 1];
+
+  const uniqueOutcomes = new Set();
+  const proseOutcome = extractFixOutcomeFromProse(transcript);
+  if (proseOutcome) uniqueOutcomes.add(proseOutcome);
+
+  if (uniqueOutcomes.size === 1) {
+    return synthesizeFixCompleteComment({
+      fixOutcome: [...uniqueOutcomes][0],
+      prNumber,
+    });
+  }
+  return "";
+}
+
+function readResultTextFromJson(resultJsonPath) {
+  const filePath = nonEmpty(resultJsonPath);
+  if (!filePath || !fs.existsSync(filePath)) return "";
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    return nonEmpty(parsed && parsed.result);
+  } catch {
+    return "";
+  }
+}
+
+function extractLatestFixCompleteCommentFromSources({
+  transcriptText,
+  transcriptPath,
+  resultJsonPath,
+  prNumber,
+}) {
+  const transcript =
+    nonEmpty(transcriptText) ||
+    (transcriptPath && fs.existsSync(transcriptPath)
+      ? fs.readFileSync(transcriptPath, "utf8")
+      : "");
+  const resultText = readResultTextFromJson(resultJsonPath);
+  const combined = [transcript, resultText].filter(Boolean).join("\n");
+  return extractLatestFixCompleteCommentFromTranscript(combined, { prNumber });
+}
+
+async function publishFixCompleteHarnessFallback({
+  owner,
+  repo,
+  repository,
+  prNumber,
+  transcriptPath,
+  transcriptText,
+  resultJsonPath,
+  token,
+  dryRun,
+  fetchImpl,
+}) {
+  const resolvedRepo = repository
+    ? { owner: repository.split("/")[0], repo: repository.split("/")[1] }
+    : { owner, repo };
+  const authToken = nonEmpty(token) || nonEmpty(process.env.GH_BOT_TOKEN);
+  if (!authToken) {
+    throw new Error("GH_BOT_TOKEN is required for harness publish fallback");
+  }
+  if (!prNumber) {
+    throw new Error("prNumber is required");
+  }
+
+  const verify = await publish.verifyFixCompleteDispatch({
+    owner: resolvedRepo.owner,
+    repo: resolvedRepo.repo,
+    prNumber,
+    token: authToken,
+    fetchImpl,
+  });
+  if (verify.ok) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: "already_published",
+      verify,
+    };
+  }
+
+  const transcript =
+    nonEmpty(transcriptText) ||
+    (transcriptPath && fs.existsSync(transcriptPath)
+      ? fs.readFileSync(transcriptPath, "utf8")
+      : "");
+  if (!transcript && !readResultTextFromJson(resultJsonPath)) {
+    return {
+      ok: false,
+      reason: "transcript_missing",
+      message: "Transcript is empty; cannot extract fix-complete comment.",
+      prior_verify: verify,
+    };
+  }
+
+  const commentBody = extractLatestFixCompleteCommentFromSources({
+    transcriptText: transcript,
+    transcriptPath: "",
+    resultJsonPath,
+    prNumber,
+  });
+  if (!commentBody) {
+    return {
+      ok: false,
+      reason: "no_comment_in_transcript",
+      message: "No valid fix-complete comment block found in harness transcript.",
+      prior_verify: verify,
+    };
+  }
+
+  const extracted = slack.extractFixOutcomeFromComment(commentBody);
+  if (!extracted.ok || extracted.value !== "ready_for_ai_review") {
+    return {
+      ok: true,
+      skipped: true,
+      reason: "fix_outcome_not_ready_for_ai_review",
+      fix_outcome: extracted.ok ? extracted.value : "",
+      prior_verify: verify,
+    };
+  }
+
+  const publishResult = await publish.publishFixCompleteAndDispatch({
+    owner: resolvedRepo.owner,
+    repo: resolvedRepo.repo,
+    prNumber,
+    commentBody,
+    token: authToken,
+    dryRun,
+    fetchImpl,
+  });
+
+  return {
+    ok: true,
+    skipped: false,
+    reason: "published",
+    synthesized: commentBody.includes("harness-fallback: synthesized"),
+    prior_verify: verify,
+    publish: publishResult,
+  };
+}
+
+function parseCliArgs(argv) {
+  const args = argv.slice(2);
+  const options = {
+    owner: "",
+    repo: "",
+    repository: "",
+    prNumber: "",
+    transcriptPath: "",
+    resultJsonPath: "",
+    dryRun: false,
+  };
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === "--repository" || arg === "-R") {
+      options.repository = args[++i] || "";
+      continue;
+    }
+    if (arg === "--owner") {
+      options.owner = args[++i] || "";
+      continue;
+    }
+    if (arg === "--repo") {
+      options.repo = args[++i] || "";
+      continue;
+    }
+    if (arg === "--pr" || arg === "--pr-number") {
+      options.prNumber = args[++i] || "";
+      continue;
+    }
+    if (arg === "--transcript") {
+      options.transcriptPath = args[++i] || "";
+      continue;
+    }
+    if (arg === "--result-json") {
+      options.resultJsonPath = args[++i] || "";
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node .github/scripts/publish-fix-complete-harness-fallback.cjs \\
+    --repository owner/repo \\
+    --pr <number> \\
+    --transcript /path/to/definition-run-transcript.log \\
+    [--result-json /path/to/definition-run-result.json] \\
+    [--dry-run]
+
+Publishes fix-complete comment + fix-ready dispatch when Cloud Agent cannot use GH_BOT_TOKEN.
+`);
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv);
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  if (!options.prNumber) {
+    throw new Error("--pr is required");
+  }
+
+  const result = await publishFixCompleteHarnessFallback(options);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!result.ok) process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  LOG_LINE_PREFIX_RE,
+  FIX_COMMAND_RESULT_HEADING,
+  extractFixCompleteCommentBlocks,
+  extractFixOutcomeFromProse,
+  synthesizeFixCompleteComment,
+  extractLatestFixCompleteCommentFromTranscript,
+  extractLatestFixCompleteCommentFromSources,
+  readResultTextFromJson,
+  publishFixCompleteHarnessFallback,
+};

--- a/.github/scripts/publish-fix-complete-harness-fallback.test.cjs
+++ b/.github/scripts/publish-fix-complete-harness-fallback.test.cjs
@@ -1,0 +1,149 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fallback = require("./publish-fix-complete-harness-fallback.cjs");
+
+const SAMPLE_COMMENT = `# Fix Review Comments Result
+
+## 1. 対応結果
+
+| 項目 | 内容 |
+| ---- | ---- |
+| Fix Outcome | \`ready_for_ai_review\` |
+| 対象PR | \`#359\` |
+
+## 12. Status更新意図
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 次Status | \`AI Review\` |
+`;
+
+const COMMAND_OUTPUT = `## fix-review-comments 実行結果
+
+### Fix Outcome
+\`ready_for_ai_review\`
+
+### 対象PR
+https://github.com/example/pull/359
+`;
+
+test("extractLatestFixCompleteCommentFromTranscript: テンプレート形式を抽出", () => {
+  const body = fallback.extractLatestFixCompleteCommentFromTranscript(SAMPLE_COMMENT, {
+    prNumber: 359,
+  });
+  assert.match(body, /Fix Review Comments Result/);
+  assert.match(body, /ready_for_ai_review/);
+});
+
+test("extractLatestFixCompleteCommentFromTranscript: Command 出力形式から合成", () => {
+  const body = fallback.extractLatestFixCompleteCommentFromTranscript(COMMAND_OUTPUT, {
+    prNumber: 359,
+  });
+  assert.match(body, /Fix Review Comments Result/);
+  assert.match(body, /ready_for_ai_review/);
+  assert.match(body, /harness-fallback: synthesized/);
+});
+
+test("publishFixCompleteHarnessFallback: verify 済みなら skip", async () => {
+  const result = await fallback.publishFixCompleteHarnessFallback({
+    repository: "o/r",
+    prNumber: 359,
+    token: "bot-token",
+    transcriptText: SAMPLE_COMMENT,
+    fetchImpl: async (url) => {
+      if (url.includes("/issues/359/comments")) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              body: SAMPLE_COMMENT,
+              created_at: "2026-06-04T07:44:00Z",
+              html_url: "https://example.com/c/1",
+            },
+          ],
+        };
+      }
+      if (url.includes("/actions/workflows/pr-ready-for-ai-review.yml/runs")) {
+        return {
+          ok: true,
+          json: async () => ({
+            workflow_runs: [
+              {
+                id: 1,
+                display_title: "fix-ready · dispatch · PR #359",
+                created_at: "2026-06-04T07:45:00Z",
+                status: "completed",
+                conclusion: "success",
+              },
+            ],
+          }),
+        };
+      }
+      throw new Error(url);
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.equal(result.reason, "already_published");
+});
+
+test("publishFixCompleteHarnessFallback: transcript から publish する", async () => {
+  const calls = [];
+  const result = await fallback.publishFixCompleteHarnessFallback({
+    repository: "o/r",
+    prNumber: 359,
+    token: "bot-token",
+    transcriptText: COMMAND_OUTPUT,
+    fetchImpl: async (url, options) => {
+      calls.push({ url, method: options && options.method });
+      if (url.includes("/issues/359/comments") && (!options || !options.method || options.method === "GET")) {
+        return { ok: true, json: async () => [] };
+      }
+      if (url.includes("/issues/359/comments") && options.method === "POST") {
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({ html_url: "https://example.com/c/2", id: 2 }),
+        };
+      }
+      if (url.includes("/dispatches")) {
+        return { ok: true, status: 204, text: async () => "" };
+      }
+      if (url.includes("/actions/workflows/pr-ready-for-ai-review.yml/runs")) {
+        return { ok: true, json: async () => ({ workflow_runs: [] }) };
+      }
+      throw new Error(`unexpected: ${url}`);
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, false);
+  assert.equal(result.reason, "published");
+  assert.equal(result.synthesized, true);
+  const postCalls = calls.filter((c) => c.method === "POST");
+  assert.ok(postCalls.length >= 1);
+  assert.ok(postCalls.some((c) => c.url.includes("/issues/359/comments")));
+});
+
+test("publishFixCompleteHarnessFallback: ready_for_ai_review 以外は publish しない", async () => {
+  const transcript = `${SAMPLE_COMMENT.replace("ready_for_ai_review", "split_required")}`;
+  const result = await fallback.publishFixCompleteHarnessFallback({
+    repository: "o/r",
+    prNumber: 10,
+    token: "bot-token",
+    transcriptText: transcript,
+    fetchImpl: async (url) => {
+      if (url.includes("/issues/10/comments")) {
+        return { ok: true, json: async () => [] };
+      }
+      if (url.includes("/actions/workflows/pr-ready-for-ai-review.yml/runs")) {
+        return { ok: true, json: async () => ({ workflow_runs: [] }) };
+      }
+      throw new Error(url);
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.skipped, true);
+  assert.equal(result.reason, "fix_outcome_not_ready_for_ai_review");
+});

--- a/.github/workflows/definition-run.yml
+++ b/.github/workflows/definition-run.yml
@@ -371,6 +371,26 @@ jobs:
             --since "${STARTED_AT}"
           echo "::endgroup::"
 
+      - name: Publish Fix complete (bot fallback)
+        if: success() && steps.resolve.outputs.command == 'fix-review-comments' && steps.resolve.outputs.run_mode == 'live-run'
+        env:
+          GH_BOT_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+          TARGET_PR: ${{ steps.resolve.outputs.target_pr }}
+          RESULT_JSON: ${{ runner.temp }}/definition-run-result.json
+        run: |
+          set -euo pipefail
+          echo "::group::publish-fix-complete-bot-fallback"
+          if [ -z "${GH_BOT_TOKEN:-}" ]; then
+            echo "::error::missing_gh_bot_token secret is required for fix-review-comments live-run publish fallback"
+            exit 1
+          fi
+          node .github/scripts/publish-fix-complete-harness-fallback.cjs \
+            --repository "${{ github.repository }}" \
+            --pr "${TARGET_PR}" \
+            --transcript "${RUNNER_TEMP}/definition-run-transcript.log" \
+            --result-json "${RESULT_JSON}"
+          echo "::endgroup::"
+
       - name: Post-run verification
         if: always()
         id: postverify

--- a/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
+++ b/docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md
@@ -27,6 +27,8 @@ Definition Run の通称・Command 定義・Task Definition 構造の正本は�
 | 単体テスト | `.github/scripts/definition-run-prompt-builder.test.cjs` | builder の正常系・異常系・secret マスクの検証 |
 | 共通 script | `.github/scripts/definition-run-post-verify.cjs` | 実行後の Issue / PR / Branch 新規作成検知、**review-pr dispatch 忘れ検証**、違反判定、Job Summary 用 Markdown 生成 |
 | 単体テスト | `.github/scripts/definition-run-post-verify.test.cjs` | post-verify の正常系・違反検出系の検証 |
+| 共通 script | `.github/scripts/publish-fix-complete-harness-fallback.cjs` | **fix-review-comments live-run** 時の fix-complete 投稿・fix-ready dispatch bot fallback |
+| 単体テスト | `.github/scripts/publish-fix-complete-harness-fallback.test.cjs` | fix-complete fallback の抽出・publish 検証 |
 | Actions 表示名 | `Definition Run Harness` | |
 
 ## 3. トリガ
@@ -73,8 +75,9 @@ on:
 2. 入力検証 (Command レジストリ参照 / definition パス prefix / 実ファイル存在 / definition_type 整合 / run_mode==dry-run)
 3. プロンプト組み立て (builder スクリプト呼び出し、secret マスク)
 4. Cursor SDK で Cloud Agent 起動 (Agent.create + agent.send + cloud: { repos: [{ url, startingRef }] }, autoCreatePR: false)
-5. **review-pr live-run のみ:** transcript（および Agent `run.result`）から AI Review コメントを抽出し `GH_BOT_TOKEN` で `publish-ai-review-and-dispatch.cjs` を実行（bot fallback）。**切り詰め本文（`/tmp` 等ローカルファイル参照・「全文は … を参照」・省略マーカー）は投稿前に拒否し、抽出対象からも除外する**
-6. post-run 検証 (Issue / PR / Branch 新規作成監視、**コメント本文の切り詰め検知** → 違反検知時は job 失敗)
+5. **review-pr live-run:** transcript（および Agent `run.result`）から AI Review コメントを抽出し `GH_BOT_TOKEN` で `publish-ai-review-and-dispatch.cjs` を実行（bot fallback）。**切り詰め本文（`/tmp` 等ローカルファイル参照・「全文は … を参照」・省略マーカー）は投稿前に拒否し、抽出対象からも除外する**
+5b. **fix-review-comments live-run:** transcript（および Agent `run.result`）から fix-complete コメントを抽出し `GH_BOT_TOKEN` で `publish-fix-complete-and-dispatch.cjs` を実行（bot fallback）。Fix Outcome が `ready_for_ai_review` のときのみ投稿・fix-ready dispatch する
+6. post-run 検証 (Issue / PR / Branch 新規作成監視、**review-pr 時のコメント切り詰め検知** → 違反検知時は job 失敗)
 7. Job Summary 出力 ($GITHUB_STEP_SUMMARY、secret スキャナ通過後)
 ```
 
@@ -88,7 +91,7 @@ on:
 | permissions | `issues: read` | post-verify で Issue 一覧取得 |
 | permissions | `pull-requests: read` | post-verify で PR 一覧取得 |
 | Secret | `CURSOR_API_KEY` | Cursor SDK の認証。workflow env のみで使用、プロンプト・log・Summary には絶対に出さない |
-| Secret | `GH_BOT_TOKEN` | **`review-pr` + `live-run` 時**の `publish-ai-review-and-dispatch.cjs` bot fallback（Cloud Agent は PR コメント POST 不可） |
+| Secret | `GH_BOT_TOKEN` | **`review-pr` / `fix-review-comments` + `live-run` 時**の bot fallback（`publish-ai-review-and-dispatch.cjs` / `publish-fix-complete-and-dispatch.cjs`。Cloud Agent は PR コメント POST 不可） |
 | Token | `GITHUB_TOKEN` | post-verify で gh API を叩く（read のみ。write 全廃） |
 | permissions | `actions: read` | review-pr post-verify で workflow runs 参照 |
 
@@ -240,7 +243,7 @@ Issue 作成・更新後の同期は既存 workflow が行うため、Harness �
 2. Cloud Agent 完了後、`started_at` 以降に作成された Issue / PR / Branch の有無を gh API で確認
 3. 違反検知ルール:
    - dry-run なのに新規 Issue / PR / Branch が作成されていたら **違反**
-   - `review-pr` 実行時は `target_pr` の head branch を branch 監視対象から除外する（対象 PR ブランチへの並行 push を誤検知しないため）
+   - `review-pr` / `fix-review-comments` 実行時は `target_pr` の head branch を branch 監視対象から除外する（対象 PR ブランチへの push を誤検知しないため）
    - 違反内容（種別・番号・URL・作成時刻・actor）を Job Summary の Guard Violations 欄に列挙
    - 検出時は `process.exit(1)` で job を失敗扱いにする
 4. 違反がなければ `violations: []` を Job Summary に記録
@@ -432,6 +435,10 @@ Task Definition が解決できない場合は `--definition prompts/definitions
 ### 16.2 Harness job 失敗（dispatch 成功後）
 
 Fixer harness live-run（`command=fix-review-comments`）が失敗した場合は §12 の一般失敗扱いとする。recovery は Harness を直接再 dispatch する。
+
+**post-verify の Branch 違反（PR head への push）:** Task #360 以前は `fix-review-comments` で head branch 除外がなく、Agent 成功後も job が失敗し得た。修正後は §10.2 と同様に除外する。
+
+**Fix 完了未投稿:** Cloud Agent は `GITHUB_TOKEN`（read）で PR コメント・dispatch 不可。Harness は `publish-fix-complete-harness-fallback.cjs`（`GH_BOT_TOKEN`）で fix-complete 投稿と fix-ready dispatch を行う。未設定時は step が失敗する（`review-pr` bot fallback と同型）。
 
 ```bash
 gh workflow run "Definition Run Harness" \

--- a/docs/06_実装設計/github_actions/Fixer自動dispatch設計書.md
+++ b/docs/06_実装設計/github_actions/Fixer自動dispatch設計書.md
@@ -183,6 +183,11 @@ node .github/scripts/dispatch-fix-review-harness.cjs \
 
 Definition Run Harness 本体が失敗した場合は [Definition Run Harnessワークフロー仕様書](./Definition%20Run%20Harnessワークフロー仕様書.md) §16.2 に従う（Fixer harness live-run の recovery）。
 
+| 失敗種別 | 典型原因 | recovery |
+| -------- | -------- | -------- |
+| post-verify Branch 違反 | （修正前）PR head への正当 push を誤検知 | develop に Task #360 修正を取り込み再 dispatch |
+| Agent 成功・fix-complete 未投稿 | Cloud Agent の GitHub write 不可 | Harness `publish-fix-complete-harness-fallback`（`GH_BOT_TOKEN`）または手動 `publish-fix-complete-and-dispatch.cjs` / fix-ready workflow_dispatch |
+
 ---
 
 ## 9. Status 遷移（参考）

--- a/prompts/definitions/tasks/definition-run-harness/fix-review-post-verify-and-fallback.yaml
+++ b/prompts/definitions/tasks/definition-run-harness/fix-review-post-verify-and-fallback.yaml
@@ -1,0 +1,171 @@
+schema_version: "1.0"
+definition_type: "task"
+
+task:
+  id: "task-definition-run-fix-review-post-verify-and-fallback"
+  title: "Definition Run:fix-review-comments post-verify除外とFix完了bot fallback"
+  summary: "fix-review-comments live-run で PR head branch push を post-verify 誤検知しないよう除外し、Fix 完了コメント・fix-ready dispatch を review-pr 対称の Harness bot fallback で自動化する。"
+  phase: "06_実装設計"
+
+work_mode: "ai-agent"
+
+parent:
+  epic_issue: null
+  epic_issue_number: null
+  epic_branch: null
+  related_issues:
+    - 360
+  related_prs: []
+
+commands:
+  primary: "/work-issue"
+  allowed:
+    - "/work-issue"
+    - "/create-pr"
+    - "/review-pr"
+    - "/summarize-work"
+  next:
+    success: "/create-pr"
+    review_fix: "/fix-review-comments"
+    blocked: null
+
+agent:
+  primary: "worker-ai"
+  support:
+    - "support-ai"
+  review:
+    - "reviewer-ai"
+    - "test-ai"
+
+background: |
+  PR #359 / Harness run 26937995112 で、Fixer Cloud Agent は finished かつ PR head へ push 済みだが、
+  post-verify が fix-review-comments 時に PR head branch 更新を Branch 違反と誤判定して job が失敗した。
+  また Cloud Agent は GITHUB_TOKEN read のみのため fix-complete 投稿・fix-ready dispatch が未実施だった。
+  review-pr には post-verify head 除外と publish-ai-review-harness-fallback があるが、fix-review-comments には未整備。
+
+objective: |
+  fix-review-comments live-run の正常系（同一 PR head への push）で Harness が成功完走し、
+  Fix Outcome ready_for_ai_review 時に bot fallback 経由で fix-complete 投稿と fix-ready dispatch が行われるようにする。
+
+scope:
+  - "definition-run-post-verify.cjs（fix-review-comments + target_pr 時の head branch 除外）"
+  - "definition-run-post-verify.test.cjs"
+  - "publish-fix-complete-harness-fallback.cjs（新規）"
+  - "publish-fix-complete-harness-fallback.test.cjs（新規）"
+  - "definition-run.yml（Fix 完了 bot fallback ステップ）"
+  - "Definition Run Harnessワークフロー仕様書 §10.2 / §16"
+  - "Fixer自動dispatch設計書（bot fallback 追記）"
+  - "prompts/definitions/tasks/definition-run-harness/fix-review-post-verify-and-fallback.yaml（本 Task）"
+
+out_of_scope:
+  - "apps/** / packages/**"
+  - "fix-review-comments Command 本体（.cursor/commands）の出力形式変更"
+  - "post-verify の Phase D actor 区別ロジック全面有効化"
+  - "review-pr の既存 fallback / post-verify 挙動変更（回帰防止のため最小差分）"
+
+input:
+  docs:
+    - path: "docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md"
+      required: true
+    - path: "docs/06_実装設計/github_actions/Fixer自動dispatch設計書.md"
+      required: true
+  files:
+    - path: ".github/scripts/definition-run-post-verify.cjs"
+      required: true
+    - path: ".github/scripts/publish-ai-review-harness-fallback.cjs"
+      required: true
+    - path: ".github/scripts/publish-fix-complete-and-dispatch.cjs"
+      required: true
+    - path: ".github/workflows/definition-run.yml"
+      required: true
+  issues: []
+  prs: []
+
+output:
+  docs:
+    - path: "docs/06_実装設計/github_actions/Definition Run Harnessワークフロー仕様書.md"
+      action: "update"
+      required: true
+    - path: "docs/06_実装設計/github_actions/Fixer自動dispatch設計書.md"
+      action: "update"
+      required: true
+  files:
+    - path: ".github/scripts/definition-run-post-verify.cjs"
+      action: "update"
+      required: true
+    - path: ".github/scripts/publish-fix-complete-harness-fallback.cjs"
+      action: "create"
+      required: true
+    - path: ".github/workflows/definition-run.yml"
+      action: "update"
+      required: true
+
+deliverables:
+  - "fix-review-comments live-run の post-verify 誤検知解消"
+  - "Fix 完了 Harness bot fallback"
+  - "単体テスト"
+
+acceptance_criteria:
+  - "fix-review-comments + target_pr live-run で PR head branch への commit 更新が violation にならない"
+  - "別 branch への更新は引き続き violation"
+  - "fix-review-comments live-run 成功後、GH_BOT_TOKEN 設定時に publish-fix-complete-harness-fallback が fix-complete 投稿と fix-ready dispatch を行う（verify 済みなら skip）"
+  - "node --test で post-verify / fix-complete fallback テストが pass"
+  - "Harness 仕様書に fix-review-comments の head 除外と bot fallback が記載されている"
+
+branch:
+  name: "fix/task-360-definition-run-fix-review-harness"
+  base: "develop"
+  target: "develop"
+  worktree_required: false
+
+issue:
+  unit: "task"
+  type: "fix"
+  area: "infra"
+
+project:
+  fields:
+    status: "Todo"
+    phase: "06_実装設計"
+    priority: "high"
+    planned_start: null
+    due_date: null
+
+milestone:
+  name: null
+
+review:
+  human_review_required: true
+  ai_review_required: true
+  review_points:
+    - "review-pr との対称性（head 除外・bot fallback）"
+    - "別 branch 新規作成は引き続き違反"
+    - "fix-complete コメント形式（テンプレート / Command 出力）の抽出"
+  specialist_reviews:
+    docs: true
+    test: true
+    contract: false
+    security: true
+
+test_policy:
+  required:
+    - "node --test .github/scripts/definition-run-post-verify.test.cjs"
+    - "node --test .github/scripts/publish-fix-complete-harness-fallback.test.cjs"
+  commands:
+    - "node --test .github/scripts/definition-run-post-verify.test.cjs"
+    - "node --test .github/scripts/publish-fix-complete-harness-fallback.test.cjs"
+  manual_checks:
+    - "develop merge 後、request_changes 経路で Harness fix-review-comments が Guard Violations None で完走すること（任意・別検証）"
+  not_required:
+    - "apps integration test"
+  skip_reason:
+    "apps integration test": "Harness スクリプト・workflow のみ"
+
+operation_logging:
+  level: "standard"
+  ai_logs:
+    cross_cutting: false
+
+notes:
+  - "事象: Actions run 26937995112（PR #359）"
+  - "正本: Definition Run Harnessワークフロー仕様書 §10.2 / §16"


### PR DESCRIPTION
## 概要

Fixer harness（`fix-review-comments` live-run）が PR head への正当な push を post-verify で誤検知して失敗する問題（PR #359 / run 26937995112）を恒久対応する。あわせて Cloud Agent が投稿できない fix-complete コメント・fix-ready dispatch を `review-pr` と対称の bot fallback で自動化する。

Related to #360

## 変更内容

### Task1: post-verify

- `definition-run-post-verify.cjs`: `fix-review-comments` + `target_pr` 時も PR head branch を `excludedPrHeadRef` から除外（`review-pr` と同型）
- 単体テスト追加

### Task2: Fix 完了 bot fallback

- `publish-fix-complete-harness-fallback.cjs` 新規（transcript / Command 出力から fix-complete 抽出・合成、`publish-fix-complete-and-dispatch.cjs` 実行）
- `definition-run.yml`: `fix-review-comments` live-run 成功後に bot fallback ステップ（`GH_BOT_TOKEN` 必須）
- 単体テスト追加

### docs

- Definition Run Harnessワークフロー仕様書 §5 / §6 / §10.2 / §16.2 / 実装ファイル一覧
- Fixer自動dispatch設計書 §8.3

### Task Definition

- `prompts/definitions/tasks/definition-run-harness/fix-review-post-verify-and-fallback.yaml`

## テスト

- [x] `node --test .github/scripts/definition-run-post-verify.test.cjs`
- [x] `node --test .github/scripts/publish-fix-complete-harness-fallback.test.cjs`

## 未実施

- develop merge 後の実 PR 経由 Fixer harness E2E（手動・別検証推奨）

## Human Review 観点

- `review-pr` との対称性（head 除外・bot fallback）
- 別 branch 新規作成は引き続き post-verify 違反であること
- `GH_BOT_TOKEN` 未設定時は fix-review-comments live-run の fallback step が失敗する（review-pr と同型）

## 参照

- Issue: #360
- 事象 Run: https://github.com/ryo-chan-k6/GiftRecommendAPP_MVP_CYCLE_3/actions/runs/26937995112


Made with [Cursor](https://cursor.com)