### PR TITLE
[Task]API-INT-002:Internal401のPublicマップ方針確定 (#374)

### DIFF
--- a/ai-logs/human-decisions/2026-06-05-api-int-002-internal-401-public-map-policy.md
+++ b/ai-logs/human-decisions/2026-06-05-api-int-002-internal-401-public-map-policy.md
@@ -1,0 +1,85 @@
+# Human Decision Log
+
+## 1. 概要
+
+| 項目          | 内容 |
+| ------------- | ---- |
+| Log ID        | `2026-06-05-api-int-002-internal-401-public-map-policy` |
+| Log種別       | `human-decision` |
+| 件名          | API-INT-002 Internal 認証エラー（`GRS-AUTH-*`）の Public マップ方針 |
+| 発生日時      | 2026-06-05 |
+| 記録日時      | 2026-06-05 |
+| 発生元        | spike Task（human-led） |
+| 関連Issue     | `#374` |
+| 親 Epic       | `#366` |
+| 関連PR        | （spike PR 作成後に追記） |
+| 重要度        | `high` |
+| 状態          | `resolved` |
+
+---
+
+## 2. 結論
+
+api（`apps/api`）が reco（API-INT-002）から受け取る Internal の `GRS-AUTH-*`（HTTP 401/403）は、Public API（API-PUB-002）へ **そのまま返却しない**。
+
+| 項目 | 確定方針 |
+| ---- | -------- |
+| Public HTTP Status | **500** |
+| Public `error.code` | **`GRS-REC-002`** |
+| Public `error.message` | エラーコード定義書の `GRS-REC-002` ユーザー向け文言 |
+| `meta.traceId` / `meta.requestId` | 維持 |
+| error_log（内部） | 原文の `GRS-AUTH-*`・Internal HTTP Status・upstream を保持 |
+| MVP の Public 401 | API-PUB-002 では定義しない（匿名 Public。後続認証は別 Issue） |
+
+契約仕様書への反映: `docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md` §8.2.1、§14.1 No.2。
+
+---
+
+## 3. human-decision として記録する理由
+
+- 契約仕様書 §14 未決 No.2 は **Human + api 実装** の判断が必要とされていた
+- Public への `GRS-AUTH-*` 露出はセキュリティ・UX（MVP 匿名）に影響する
+- 後続の実装仕様書・MOD-API-013・API-PUB-002 契約の入力となる
+
+---
+
+## 4. 選択肢と採否
+
+| 案 | 概要 | 採否 |
+| --- | ---- | ---- |
+| A | 500 + `GRS-REC-002`、`GRS-AUTH-*` 非露出、error_log に原文 | **採用** |
+| B | 500 + `GRS-COM-999` | 不採用（REC 系メトリクス・UI 分類から外れる） |
+| C | 503 + `GRS-COM-003` | 不採用（`GRS-AUTH-*` は retryable:false。ユーザー再試行は無効） |
+| D | Public 401 + `GRS-AUTH-*` 透過 | 不採用（契約 §8.2・MVP 匿名 Public と矛盾） |
+
+---
+
+## 5. Human 承認
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 承認者 | Human（Issue #374 作業者） |
+| 承認日 | 2026-06-05 |
+| 承認内容 | 案A（500 + `GRS-REC-002`）を確定方針とする |
+
+---
+
+## 6. 後続への引き渡し
+
+| 後続 Task | 入力 |
+| --------- | ---- |
+| API-INT-002 実装仕様書 | §8.2.1 マップ表、reco-client エラーハンドリング、api 事前 Key 検証 |
+| API-PUB-002 契約仕様書 | Public Error 一覧に「Internal 認証失敗は `GRS-REC-002` に集約」と参照 |
+| api 実装 | MOD-API-013 変換テーブル、reco 401 モックの単体テスト |
+
+---
+
+## 7. 関連正本
+
+| ドキュメント | 参照 |
+| ------------ | ---- |
+| API-INT-002 契約仕様書 | §8.2、§8.2.1、§14.1 |
+| エラーコード定義書 | §3.1、§9、§24 |
+| API設計方針書 | §11.1–11.3（MVP 匿名 Public） |
+| インターフェース一覧 | §15 補足 |
+| Issue #374 | https://github.com/ryo-chan-k6/GiftRecommendAPP_MVP_CYCLE_3/issues/374 |

--- a/ai-logs/human-decisions/2026-06-05-api-int-002-internal-401-public-map-policy.md
+++ b/ai-logs/human-decisions/2026-06-05-api-int-002-internal-401-public-map-policy.md
@@ -12,7 +12,7 @@
 | 発生元        | spike Task（human-led） |
 | 関連Issue     | `#374` |
 | 親 Epic       | `#366` |
-| 関連PR        | （spike PR 作成後に追記） |
+| 関連PR        | `#377` |
 | 重要度        | `high` |
 | 状態          | `resolved` |
 

--- a/docs/05_アプリケーション設計/アプリ/インターフェース一覧.md
+++ b/docs/05_アプリケーション設計/アプリ/インターフェース一覧.md
@@ -562,6 +562,8 @@ flowchart TD
 | Workflow IF     | job失敗 / timeout / secrets不足                | `GRS-BAT-*` / `GRS-COM-*`                            | GitHub Actions結果とbatch_run_logを突合可能にする |
 | 共通ロジックIF  | Feature生成失敗 / Version不整合                | `GRS-CFG-*` / `GRS-BAT-*` / `GRS-REC-*`              | 対象itemまたはrun単位で失敗記録する               |
 
+> **補足（API-INT-002 / #374）:** api→reco 経路で reco が返す Internal `GRS-AUTH-*`（401/403）は Public へ露出せず、API-PUB-002 向けには **500 + `GRS-REC-002`** に集約する。正本は `docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md` §8.2.1。
+
 ---
 
 ## 16. インターフェース別データ契約概要

--- a/docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md
+++ b/docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md
@@ -13,7 +13,7 @@
 | 対象システム   | Gift Recommendation Service MVP（Internal） |
 | MVP対象        | `○`                                       |
 | 作成日         | 2026-06-04                                |
-| 更新日         | 2026-06-04（Human Review 指摘・未決事項 Issue 化） |
+| 更新日         | 2026-06-05（§14 No.2 確定：Internal 401 Public マップ方針 #374） |
 
 ---
 
@@ -421,13 +421,13 @@ Internal API では API設計方針書 §21.3 に従い、Public より多くの
 
 ### 8.2 Error一覧（本 API で想定する代表）
 
-| Status | Error Code | 発生条件 | Response概要 | ユーザー向け表示 |
-| -----: | ---------- | -------- | ------------ | ---------------- |
-| 401 | `GRS-AUTH-001` | Internal API Key 不正 | 認証失敗 | Public には露出しない（api 実装仕様書でマップ方針を確定） |
-| 401 | `GRS-AUTH-004` | 内部認証情報なし | 認証情報不足 | 同上 |
-| 403 | `GRS-AUTH-002` | 許可されない操作 | 権限不足 | Public には露出しない |
-| 403 | `GRS-AUTH-003` | Public 向け API への不正アクセス相当 | 操作不可 | 同上 |
-| 403 | `GRS-AUTH-005` | Batch 操作の外部実行 | 操作不可 | 同上 |
+| Status | Error Code | 発生条件 | Response概要 | Public 向けマップ（API-PUB-002） |
+| -----: | ---------- | -------- | ------------ | -------------------------------- |
+| 401 | `GRS-AUTH-001` | Internal API Key 不正 | 認証失敗 | §8.2.1 参照（500 + `GRS-REC-002`） |
+| 401 | `GRS-AUTH-004` | 内部認証情報なし | 認証情報不足 | §8.2.1 参照（500 + `GRS-REC-002`） |
+| 403 | `GRS-AUTH-002` | 許可されない操作 | 権限不足 | §8.2.1 参照（500 + `GRS-REC-002`） |
+| 403 | `GRS-AUTH-003` | Public 向け API への不正アクセス相当 | 操作不可 | §8.2.1 参照（500 + `GRS-REC-002`） |
+| 403 | `GRS-AUTH-005` | Batch 操作の外部実行 | 操作不可 | §8.2.1 参照（500 + `GRS-REC-002`） |
 | 400 | `GRS-REQ-001` | 正規化済み Request の契約違反 | Validation 失敗 | Public `GRS-REQ-001` 等へ変換 |
 | 422 | `GRS-REQ-002` | 未対応の条件組み合わせ | 業務 Validation | Public 422 へ伝播可 |
 | 422 | `GRS-REQ-006` | 条件が厳しすぎる | 業務 Validation | 同上 |
@@ -440,6 +440,27 @@ Internal API では API設計方針書 §21.3 に従い、Public より多くの
 | 502 | `GRS-LLM-100`〜`104` | LLM / Embedding 失敗 | 外部依存 | Public 502 |
 | 504 | `GRS-LLM-101` | LLM タイムアウト | タイムアウト | Public 504 |
 | 503 | `GRS-COM-003` | 一時的利用不可（DB 接続失敗等） | サービス一時停止 | Public 503 へ集約可 |
+
+### 8.2.1 Internal 認証・認可エラーの Public マップ（確定 #374）
+
+api（`apps/api`）が reco（API-INT-002）呼び出しで受け取る `GRS-AUTH-*` は、**Public API（API-PUB-002）へそのまま返却しない**。MVP では Public API は匿名利用のため、エンドユーザー向け HTTP 401 / `GRS-AUTH-*` は定義しない（後続の会員認証導入時は API-AUT 系で別途定義）。
+
+| Internal（reco→api） | Internal HTTP | Public（api→web）HTTP | Public `error.code` | Public `error.message` |
+| -------------------- | ------------- | --------------------- | ------------------- | ---------------------- |
+| `GRS-AUTH-001` | 401 | 500 | `GRS-REC-002` | エラーコード定義書の `GRS-REC-002` ユーザー向け文言 |
+| `GRS-AUTH-004` | 401 | 500 | `GRS-REC-002` | 同上 |
+| `GRS-AUTH-002` | 403 | 500 | `GRS-REC-002` | 同上 |
+| `GRS-AUTH-003` | 403 | 500 | `GRS-REC-002` | 同上 |
+| `GRS-AUTH-005` | 403 | 500 | `GRS-REC-002` | 同上 |
+
+| 方針 | 内容 |
+| ---- | ---- |
+| `meta.traceId` / `meta.requestId` | Public 応答でも維持（§8.1） |
+| error_log（内部） | 原文の `GRS-AUTH-*`・Internal HTTP Status・`upstream=reco`（または api 側事前検証時は `upstream=api`）を記録 |
+| api 事前検証 | reco 呼び出し前に Internal API Key（環境変数）未設定時は reco を呼ばず、Public は上表と同じ 500 + `GRS-REC-002`。error_log には `GRS-AUTH-004` 相当を記録 |
+| Secret | `X-Internal-Api-Key` 実値は Response・ログに含めない |
+
+実装詳細（MOD-API-013 Error Handler、reco-client 例外変換、単体テスト）は API-INT-002 実装仕様書 Task で定義する。判断記録は `ai-logs/human-decisions/2026-06-05-api-int-002-internal-401-public-map-policy.md` を参照。
 
 `GRS-REC-001` は **HTTP 200** の正常系（0 件）として扱い、§7.4.2 を参照。エラー Response 一覧には含めない。
 
@@ -522,6 +543,7 @@ Contract Gate 通過後に Implementation Task（`api-implementation-spec`）お
 | 2026-06-04 | 初版（契約面のみ。Task #368 / 分離後モデル） | #368 |
 | 2026-06-04 | AI Review 指摘反映（`resultItems` / Result Status / Error / Validation / Observability 等） | #368 / #369 |
 | 2026-06-04 | Human Review 指摘対応：§14 未決事項を個別 Issue 化（#373〜#376） | #368 / #372 |
+| 2026-06-05 | §14 No.2 確定：Internal 認証エラーの Public マップ（§8.2.1、#374） | #374 |
 
 ---
 
@@ -529,10 +551,17 @@ Contract Gate 通過後に Implementation Task（`api-implementation-spec`）お
 
 本節の論点は **人間判断待ち** として個別 Issue で管理する（作業計画の正本は Issue。契約仕様書は論点の参照先）。
 
+### 14.1 確定済み（本書へ反映済み）
+
+| No | 論点 | 確定内容 | 反映箇所 | 追跡 Issue |
+| --: | ---- | -------- | -------- | ---------- |
+| 2 | Internal 401 の Public へのマップ方針 | `GRS-AUTH-*` は Public 非露出。api→web は **500 + `GRS-REC-002`**。内部は error_log に原文保持 | §8.2.1 | #374 |
+
+### 14.2 未決（人間判断待ち）
+
 | No | 論点 | 判断が必要な理由 | 判断者 | 期限 | 備考 | 追跡 Issue |
 | --: | ---- | ---------------- | ------ | ---- | ---- | ---------- |
 | 1 | `warnings` / `metricSummary` のスキーマ詳細 | API一覧は概要のみ。配列要素の構造を OpenAPI で固定する必要がある | Human + Contract Task | OpenAPI Task 前 | §7.3.1 | #373 |
-| 2 | Internal 401 の Public へのマップ方針 | `GRS-AUTH-*` を web に露出しない変換ルール | Human + api 実装 Task | 実装仕様書作成時 | §8.2 | #374 |
 | 3 | `scoreBreakdown` / `debug_payload` の返却条件 | evaluation / `includeDebugInfo` 時の必須度 | Human Review | Contract Gate 前 | Recommendation Result 定義書 §9.2 参照 | #375 |
 | 4 | `reasonSummary` / `reasonData` の必須/任意（Internal） | Reason 生成のみ失敗時の省略可否、`reasonData` スキーマ | Human Review | Contract Gate 前 | Reason生成定義書・API-PUB-002 参照 | #376 |
 

--- a/prompts/definitions/reviews/api-int-002-internal-401-public-map-policy/pr-review.yaml
+++ b/prompts/definitions/reviews/api-int-002-internal-401-public-map-policy/pr-review.yaml
@@ -1,0 +1,168 @@
+schema_version: "1.0"
+definition_type: "review"
+
+review:
+  id: "review-api-int-002-internal-401-public-map-policy-spike-pr"
+  title: "API-INT-002 Internal401 Publicマップ方針 spike PRレビュー"
+  summary: "Issue #374（Internal 401 Public マップ方針確定）spike Task の PR を AI Review する"
+  type: "task_pr_review"
+  status: "ready"
+
+work_mode: "human-led"
+
+branch:
+  no_branch: true
+  name: null
+  base: null
+  target: null
+  worktree_required: false
+
+target:
+  pr: 377
+  issue: 374
+  task_definition: "prompts/definitions/tasks/api-int-002-internal-401-public-map-policy/spike.yaml"
+  source_branch: "spike/task-374-api-int-002-internal-401-public-map-policy"
+  target_branch: "feature/epic-366-api-int-002-reco-recommendation-run"
+  parent_epic_issue: "[Epic]API-INT-002:Reco推薦実行"
+  parent_epic_branch: "feature/epic-366-api-int-002-reco-recommendation-run"
+
+commands:
+  primary: "/review-pr"
+  allowed:
+    - "/review-pr"
+    - "/fix-review-comments"
+  next:
+    approve_for_human_review: "Human Review"
+    request_changes: "/fix-review-comments"
+    needs_human_decision: "Human Decision"
+    split_required: "/start-task"
+    blocked: null
+
+agent:
+  primary: "reviewer-ai"
+  support:
+    - "support-ai"
+  specialist:
+    docs: "docs-reviewer-ai"
+    test: null
+    contract: null
+    security: true
+  next:
+    fixer: "fixer-ai"
+    human: "human-reviewer"
+
+review_scope:
+  docs: true
+  source: false
+  tests: false
+  api_contract: false
+  db: false
+  generated: false
+  cicd: false
+  security: true
+  project_operation: true
+
+input:
+  task_definition:
+    path: "prompts/definitions/tasks/api-int-002-internal-401-public-map-policy/spike.yaml"
+    required: true
+  issue:
+    number: 374
+    required: true
+  pr:
+    number: 377
+    required: true
+  diff:
+    required: true
+    compare_with: "feature/epic-366-api-int-002-reco-recommendation-run"
+  docs:
+    - path: "docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md"
+      required: true
+      purpose: "§8.2.1 マップ表・§14.1 確定反映の確認"
+    - path: "ai-logs/human-decisions/2026-06-05-api-int-002-internal-401-public-map-policy.md"
+      required: true
+      purpose: "Human 判断記録と契約仕様書の一致確認"
+    - path: "docs/05_アプリケーション設計/アプリ/エラーコード定義書.md"
+      required: true
+      purpose: "GRS-REC-002 / GRS-AUTH-* 整合確認"
+  files: []
+  test_results:
+    required: true
+    source: "pr_body"
+  ci_results:
+    required: false
+    source: "not_required"
+  templates:
+    review_outputs:
+      pr_comment: "prompts/templates/review/ai-review-comment.md"
+      slack: "prompts/templates/slack/ai-review-result.md"
+
+review_points:
+  common:
+    - "Task Definition（spike.yaml）の scope を満たしているか"
+    - "out_of_scope（実装・OpenAPI）の変更が混在していないか"
+    - "PR 本文に Task Definition パスが記載されているか"
+    - "PR target が親 Epic Branch であるか"
+    - "Closes #374 の使用が妥当か（spike 完了として）"
+  docs:
+    - "§8.2.1 のマップ（500 + GRS-REC-002）が human-decisions と一致しているか"
+    - "GRS-AUTH-* を Public に返さないことが明記されているか"
+    - "error_log 原文保持が明記されているか"
+    - "§14 No.2 が §14.1 確定済みへ移動しているか"
+  security:
+    - "Internal API Key 実値が含まれていないか"
+
+acceptance_check:
+  use_task_acceptance_criteria: true
+  additional_criteria:
+    - "Human 方針（案A）が docs と human-decisions で一貫している"
+
+result_policy:
+  approve_for_human_review:
+    conditions:
+      - "acceptance_criteria を満たしている"
+      - "修正必須事項がない"
+  request_changes:
+    conditions:
+      - "同一 Branch で修正可能な docs 不備がある"
+      - "PR 本文に Definition または検証記載が不足している"
+  needs_human_decision:
+    conditions:
+      - "マップ方針そのものの再判断が必要"
+  blocked:
+    conditions:
+      - "Task Definition が解決できない"
+      - "secret 混入の疑い"
+
+status_policy:
+  current_status: "AI Review"
+  on_approve: "Human Review"
+  on_request_changes: "In Progress"
+  on_needs_human_decision: "Human Review"
+  on_blocked: "In Progress"
+
+outputs:
+  pr_comment_template: "prompts/templates/review/ai-review-comment.md"
+  slack_template: "prompts/templates/slack/ai-review-result.md"
+  update_pr_body: false
+  ai_logs:
+    required: false
+    path: null
+
+issue:
+  unit: "task"
+  type: "spike"
+  area: "reco"
+
+operation_logging:
+  level: "standard"
+  ai_logs:
+    intake: false
+    incidents: false
+    cross_cutting: false
+    experiments: false
+  reason: "spike docs 反映。レビュー結果は PR コメントを正本とする。"
+
+notes:
+  - "対応 Task Definition: prompts/definitions/tasks/api-int-002-internal-401-public-map-policy/spike.yaml"
+  - "確定方針: Internal GRS-AUTH-* → Public 500 + GRS-REC-002（#374 Human 承認済み）"

--- a/prompts/definitions/tasks/api-int-002-internal-401-public-map-policy/spike.yaml
+++ b/prompts/definitions/tasks/api-int-002-internal-401-public-map-policy/spike.yaml
@@ -1,0 +1,206 @@
+schema_version: "1.0"
+definition_type: "task"
+
+task:
+  id: "task-api-int-002-internal-401-public-map-policy"
+  title: "API-INT-002:Internal401のPublicマップ方針確定"
+  summary: "API-INT-002 契約仕様書 §14 No.2（Internal 401 / GRS-AUTH-* の Public マップ）を Human 判断で確定し、契約仕様書 §8.2.1・human-decisions へ反映する（docs のみ。実装・OpenAPI 変更は対象外）。"
+
+work_mode: "human-led"
+
+parent:
+  epic_issue: "[Epic]API-INT-002:Reco推薦実行"
+  epic_issue_number: 366
+  epic_branch: "feature/epic-366-api-int-002-reco-recommendation-run"
+  related_issues:
+    - 368
+    - 372
+  related_prs:
+    - 372
+
+commands:
+  primary: "/work-issue"
+  allowed:
+    - "/work-issue"
+    - "/create-pr"
+    - "/fix-review-comments"
+    - "/review-pr"
+    - "/summarize-work"
+  next:
+    success: "/create-pr"
+    review_fix: "/fix-review-comments"
+    blocked: null
+
+agent:
+  primary: "worker-ai"
+  support:
+    - "support-ai"
+    - "orchestrator-ai"
+  review:
+    - "reviewer-ai"
+    - "docs-reviewer-ai"
+
+background: |
+  API-INT-002 契約仕様書 §14 の未決事項 No.2（Internal 401 の Public へのマップ方針）を個別 Issue #374 で管理する。
+  api→reco の Internal 認証失敗（GRS-AUTH-001 / 004 等）を、Public API（API-PUB-002）へどう変換するかを確定する。
+  MVP では Public API は匿名利用のため、GRS-AUTH-* を web に露出しない。
+
+objective: |
+  Internal GRS-AUTH-*（401/403）の Public マップ方針を Human 判断で確定し、正本 docs へ反映する。
+  確定方針（案A）: Public は HTTP 500 + GRS-REC-002。error_log に原文 GRS-AUTH-* を保持。MVP の API-PUB-002 では Public 401 を定義しない。
+
+scope:
+  - "確定マップを API-INT-002 契約仕様書 §8.2 / §8.2.1 に記載する"
+  - "§14 No.2 を確定済み（§14.1）へ移し、未決一覧から除外する"
+  - "ai-logs/human-decisions/ に判断記録を作成する"
+  - "インターフェース一覧 §15 に補足を追記する（任意・最小）"
+  - "Issue #374 完了条件（人間判断・docs 反映）を満たす"
+
+out_of_scope:
+  - "apps/api の Error Handler 実装（MOD-API-013）"
+  - "OpenAPI（internal-reco-api.yaml / Public）の変更"
+  - "API-PUB-002 契約仕様書の新規作成（参照追記のみ可）"
+  - "apps/reco / apps/web の実装変更"
+  - "認証・認可方式そのものの変更"
+
+input:
+  docs:
+    - path: "docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md"
+      required: true
+      purpose: "§8.2 / §14 No.2 の正本。マップ方針を追記する"
+    - path: "docs/05_アプリケーション設計/アプリ/エラーコード定義書.md"
+      required: true
+      purpose: "GRS-AUTH-* / GRS-REC-002 のユーザー向け文言・retryable を確認する"
+    - path: "docs/05_アプリケーション設計/アプリ/api/API設計方針書.md"
+      required: true
+      purpose: "MVP 匿名 Public・Internal API 保護方針を確認する"
+    - path: "docs/05_アプリケーション設計/アプリ/インターフェース一覧.md"
+      required: false
+      purpose: "Internal IF → Public 変換方針の横断参照"
+  templates: []
+  files: []
+  issues:
+    - number: 374
+      required: true
+      purpose: "作業計画・完了条件の正本"
+  prs: []
+
+output:
+  docs:
+    - path: "docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md"
+      action: "update"
+      required: true
+    - path: "docs/05_アプリケーション設計/アプリ/インターフェース一覧.md"
+      action: "update"
+      required: false
+  files:
+    - path: "ai-logs/human-decisions/2026-06-05-api-int-002-internal-401-public-map-policy.md"
+      action: "create"
+      required: true
+  tests: []
+  generated:
+    expected: false
+    paths: []
+    handling: "none"
+  logs:
+    ai_logs_required: true
+    path: "ai-logs/human-decisions/2026-06-05-api-int-002-internal-401-public-map-policy.md"
+
+deliverables:
+  - "Internal 401 Public マップ方針の確定（500 + GRS-REC-002、GRS-AUTH-* 非露出）"
+  - "API-INT-002 契約仕様書 §8.2.1 および §14.1 への反映"
+  - "Human 判断記録（ai-logs/human-decisions）"
+
+acceptance_criteria:
+  - "人間判断により方針（案A）が確定している"
+  - "契約仕様書 §8.2.1 に Public マップ表が記載されている"
+  - "§14 No.2 が確定済みとして整理されている"
+  - "ai-logs/human-decisions/ に決定記録がある"
+  - "Public レスポンスに GRS-AUTH-* を返さない方針が明記されている"
+  - "error_log に原文 GRS-AUTH-* を保持する方針が明記されている"
+  - "scope 外（実装・OpenAPI）の変更が含まれていない"
+  - "secret や .env 実値が含まれていない"
+
+branch:
+  no_branch: false
+  name: "spike/task-<issue-number>-api-int-002-internal-401-public-map-policy"
+  base: "feature/epic-366-api-int-002-reco-recommendation-run"
+  target: "feature/epic-366-api-int-002-reco-recommendation-run"
+  worktree_required: true
+
+project:
+  project_name: "Gift Recommendation Service MVP Cycle 3"
+  fields:
+    phase: "06_実装設計"
+    status: "Todo"
+    priority: "high"
+    planned_start: null
+    due_date: null
+
+issue:
+  unit: "task"
+  type: "spike"
+  area: "reco"
+
+dependencies:
+  epics: []
+  issues:
+    - 368
+    - 372
+  prs:
+    - 372
+  tasks:
+    - "API-INT-002 契約仕様書（#368 / #372）が存在すること"
+  blocking: false
+
+parallel_control:
+  depends_on: []
+  blocks: []
+  exclusive_files:
+    - "docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md"
+  conflict_risk: "low"
+  generated_impact: false
+  contract_impact: false
+  db_impact: false
+
+test_policy:
+  required:
+    - "docs review"
+    - "markdown format check"
+    - "secret check"
+  commands: []
+  manual_checks:
+    - "§8.2.1 のマップ表が Issue #374 確定方針と一致していること"
+    - "§14.1 に No.2 が移動していること"
+  not_required:
+    - "unit test"
+    - "integration test"
+    - "typecheck"
+    - "build"
+  skip_reason:
+    "unit test": "docs のみの spike Task のため"
+    "integration test": "実装変更を含まないため"
+    "typecheck": "source 変更を含まないため"
+    "build": "source 変更を含まないため"
+
+review:
+  human_review_required: true
+  ai_review_required: true
+  review_points:
+    - "確定マップ（500 + GRS-REC-002）が §8.2.1 と human-decisions で一致しているか"
+    - "GRS-AUTH-* が Public に露出しないことが明記されているか"
+    - "実装・OpenAPI が scope 外であること"
+
+operation_logging:
+  level: "standard"
+  ai_logs:
+    intake: false
+    incidents: false
+    cross_cutting: false
+    experiments: false
+    human_decisions: true
+  reason: "Human 判断の正本は ai-logs/human-decisions とする。"
+
+notes:
+  - "作業計画の正本は Issue #374"
+  - "Review Definition: prompts/definitions/reviews/api-int-002-internal-401-public-map-policy/pr-review.yaml"


### PR DESCRIPTION
## Summary

- Issue #374（API-INT-002 §14 No.2）の Human 判断を反映し、Internal `GRS-AUTH-*`（401/403）を Public へ露出しない方針を確定した
- 確定マップ: api→web は **HTTP 500** + **`GRS-REC-002`**。error_log には原文の `GRS-AUTH-*` を保持
- MVP の API-PUB-002 では Public 401 は定義しない（匿名 Public）

## Task Definition

Definition: `prompts/definitions/tasks/api-int-002-internal-401-public-map-policy/spike.yaml`

## 変更ファイル

| ファイル | 内容 |
| -------- | ---- |
| `docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md` | §8.2 Public マップ列、§8.2.1 確定表、§14.1 確定済み |
| `docs/05_アプリケーション設計/アプリ/インターフェース一覧.md` | §15 補足（#374） |
| `ai-logs/human-decisions/2026-06-05-api-int-002-internal-401-public-map-policy.md` | Human 決定記録 |
| `prompts/definitions/tasks/api-int-002-internal-401-public-map-policy/spike.yaml` | Task Definition（Fixer / Harness 解決用） |
| `prompts/definitions/reviews/api-int-002-internal-401-public-map-policy/pr-review.yaml` | Review Definition |

## 関連

- Closes #374
- 親 Epic: #366
- 起票元: #372 / 契約仕様書 §14

## Test plan

- [x] docs の Markdown 表・参照リンクを目視確認
- [x] Task Definition 解決（`resolve-task-definition.cjs` で spike.yaml を確認）
- [ ] コード変更なし（spike / docs のみ）
- [ ] 実装・単体テストは後続 api 実装仕様書 Task で実施

## Human Review 観点

- Public に `GRS-AUTH-*` が残っていないか
- 500 + `GRS-REC-002` で MVP UX が妥当か
- error_log 原文保持の運用が明記されているか
- §14 No.2 のクローズ条件を満たすか