### PR TITLE
[Task]API-INT-001:RecoヘルスチェックAPI契約仕様書作成

### DIFF
--- a/docs/06_実装設計/api/API-INT-001_RecoヘルスチェックAPI契約仕様書.md
+++ b/docs/06_実装設計/api/API-INT-001_RecoヘルスチェックAPI契約仕様書.md
@@ -1,0 +1,375 @@
+# Recoヘルスチェック API契約仕様書
+
+> 本書は **API-INT-001** の契約面（Internal I/F）正本である。
+> 処理フロー・依存チェック実装詳細・結合テスト観点は `API-INT-001_RecoヘルスチェックAPI実装仕様書.md`（別 Task）で定義する。
+> OpenAPI 正本は `packages/contracts/openapi/internal-reco-api.yaml`（別 Contract Task）。
+
+## 1. ドキュメント情報
+
+| 項目           | 内容                                      |
+| -------------- | ----------------------------------------- |
+| ドキュメントID | `API-INT-001-CONTRACT`                    |
+| ドキュメント名 | Recoヘルスチェック API契約仕様書          |
+| 対象システム   | Gift Recommendation Service MVP（Internal） |
+| MVP対象        | `○`                                       |
+| 作成日         | 2026-06-05                                |
+| 更新日         | 2026-06-05                                |
+
+---
+
+## 2. 概要
+
+api（`apps/api`）から reco（`apps/reco` エンドポイント層）の稼働状態を確認する Internal API である。推薦パイプラインは実行せず、reco サービスが HTTP で応答可能かを返す。
+
+本書では **api↔reco 間の HTTP 契約** のみを定義する。推薦ロジック（MOD-RECO-001 等）の内部処理は本書の scope 外とする。
+
+---
+
+## 3. 目的
+
+- api→reco 間の Request / Response / Error / Validation を確定し、Contract Gate および後続 OpenAPI Contract Task の入力とする。
+- API設計方針書・API一覧・エラーコード定義書と整合した Internal 契約面を提供する。
+- api が Reco Client（MOD-API-005）経由で reco 接続確認を行う際の I/F 境界を明確にする。
+
+---
+
+## 4. API基本情報
+
+| 項目     | 内容                                              |
+| -------- | ------------------------------------------------- |
+| API ID   | `API-INT-001`                                     |
+| API名    | Recoヘルスチェック                                |
+| API種別  | `Internal API`                                    |
+| Method   | `GET`                                             |
+| Endpoint | `/internal/reco/v1/health`                        |
+| Base URL | 環境ごとに環境変数で定義（本書ではパスを正とする） |
+| Version  | `v1`（URL パスに含む）                            |
+| Provider | `apps/reco`（エンドポイント層）                   |
+| Consumer | `apps/api`（MOD-API-005 Reco Client 等）          |
+| 認証要否 | `true`（Internal API Key。詳細は §6.1）           |
+| 権限条件 | サービス間呼び出しのみ。外部ユーザー直接利用不可  |
+| 冪等性   | `冪等`（副作用なし。同一 Request の繰り返し可）   |
+| MVP対象  | `○`                                               |
+
+---
+
+## 5. 利用シーン
+
+### 5.1 利用タイミング
+
+- api 起動時・定期監視・レコメンド実行前の reco 疎通確認時
+- 運用確認（api / 監視ツールからの内部呼び出し）
+
+### 5.2 呼び出し元
+
+- `apps/api`（Reco Client / 運用確認処理）
+
+### 5.3 主なユースケース
+
+- reco が常駐サービスとして稼働していることを確認する。
+- reco が応答不能の場合、api 側で接続エラーまたは 5xx を検知し、後続処理（API-INT-002 等）を抑制またはエラー表示する。
+
+### 5.4 関連モジュール（参照のみ）
+
+| 項目 | 内容 |
+| ---- | ---- |
+| Consumer モジュール | `MOD-API-005`（Reco Client）— 本 API の呼び出し責務 |
+| Provider 境界 | `apps/reco` エンドポイント層（HTTP I/F） |
+| 後続 Internal API | `API-INT-002`（Reco推薦実行）— ヘルス確認後に実行される推薦 API |
+
+---
+
+## 6. Request仕様
+
+### 6.1 Request Header
+
+| Header | 必須 | 内容 | 例 |
+| ------ | ---- | ---- | -- |
+| `Accept` | `true` | `application/json` | `application/json` |
+| `X-Internal-Api-Key` | `true` | Internal API 保護用キー（値は環境変数。本書に実値を記載しない） | `***REDACTED***` |
+| `X-Trace-Id` | `false` | 横断追跡 ID。指定時は Response `meta.traceId` へ反映 | `550e8400-e29b-41d4-a716-446655440000` |
+| `X-Request-Id` | `false` | API リクエスト ID。指定時は Response `meta.requestId` へ反映 | `req_01HZYX` |
+
+Internal API は API設計方針書 §11.3 に従い `X-Internal-Api-Key` で保護する。`X-Trace-Id` / `X-Request-Id` は API一覧上 trace_id 対象が **任意** のため必須としない。指定された場合は reco 側で Response `meta` へ反映する。
+
+### 6.2 Path Parameters
+
+| 項目 | 型 | 必須 | 内容 | 例 |
+| ---- | -- | ---- | ---- | -- |
+| - | - | - | なし | - |
+
+### 6.3 Query Parameters
+
+| 項目 | 型 | 必須 | 内容 | 制約 | 例 |
+| ---- | -- | ---- | ---- | ---- | -- |
+| - | - | - | なし | - | - |
+
+### 6.4 Request Body
+
+なし（GET のため Request Body を使用しない。API設計方針書 §7.4）。
+
+### 6.5 Request Example
+
+```http
+GET /internal/reco/v1/health HTTP/1.1
+Host: reco.internal.example
+Accept: application/json
+X-Internal-Api-Key: ***REDACTED***
+X-Trace-Id: 550e8400-e29b-41d4-a716-446655440000
+```
+
+### 6.6 Observability（契約露出範囲）
+
+| 項目 | 露出箇所 | 必須 | 内容 |
+| ---- | -------- | ---- | ---- |
+| `traceId` | Request Header `X-Trace-Id`（任意）/ Response `meta.traceId` | `false` | 指定時は往復一致 |
+| `requestId` | Request Header `X-Request-Id`（任意）/ Response `meta.requestId` | `false` | 指定時は往復一致 |
+
+access_log / metric の**実装・記録詳細**は実装仕様書 Task で扱う（ログ・Observability設計書を正本とする）。契約上、metric 対象は `reco_health_check_count`（API一覧）とする。
+
+---
+
+## 7. Response仕様
+
+### 7.1 Response Header
+
+| Header | 内容 | 例 |
+| ------ | ---- | -- |
+| `Content-Type` | `application/json` | `application/json` |
+
+### 7.2 Status Code
+
+| Status | 意味 | 利用条件 |
+| -----: | ---- | -------- |
+| 200 | reco 稼働確認成功 | reco が正常応答し、契約上の稼働状態を返却できる場合 |
+| 401 | 認証失敗 | `X-Internal-Api-Key` 不正または未指定 |
+| 403 | 権限不足 | Internal API への不正アクセス（`GRS-AUTH-002` 等） |
+| 500 | 内部エラー | reco 内部の想定外エラー（`GRS-COM-999` / `GRS-REC-002` 等） |
+| 503 | 一時利用不可 | reco が起動中だが依存（DB 等）が利用不可（`GRS-COM-003` 等） |
+
+ヘルスチェックは **推薦未実行** のため、400 / 422 / 502 / 504 は通常発生しない。api 側の HTTP クライアントタイムアウトは接続エラーとして扱い、実装仕様書 Task で整理する。
+
+**稼働不良と HTTP Status:** reco プロセスは応答するが内部依存が不全の場合、HTTP **503** と `data.status: degraded` の組み合わせを許容する（§7.3.1）。
+
+### 7.3 Response Body
+
+成功時は API設計方針書 §8.2 の **`data` + `meta`** 構造を基本とする。
+
+#### 7.3.1 `data`（稼働状態）
+
+| 項目 | 型 | 必須 | 内容 | 備考 |
+| ---- | -- | ---- | ---- | ---- |
+| `status` | `string` | `true` | 稼働状態 | MVP 値域: `ok` / `degraded` / `unavailable` |
+| `service` | `string` | `true` | サービス識別子 | 固定値 `reco` |
+| `version` | `string` | `false` | アプリケーションバージョン | デプロイ識別用。未設定可 |
+| `checkedAt` | `string` | `false` | 確認日時（ISO 8601） | reco 側生成時刻 |
+
+| `status` 値 | HTTP Status（典型） | 意味 |
+| ----------- | ------------------- | ---- |
+| `ok` | 200 | reco プロセスが正常応答し、MVP で必要な最小依存が利用可能 |
+| `degraded` | 200 または 503 | reco は応答するが一部依存が不全（詳細チェックは実装 Task） |
+| `unavailable` | 503 | reco が利用不可 |
+
+MVP 初版では `status: ok` のみを必須成功パターンとし、`degraded` / `unavailable` の判定条件詳細は実装仕様書 Task で確定する。
+
+#### 7.3.2 `meta`
+
+| 項目 | 型 | 必須 | 内容 | 備考 |
+| ---- | -- | ---- | ---- | ---- |
+| `traceId` | `string` | `false` | 横断追跡 ID | Header `X-Trace-Id` 指定時は一致 |
+| `requestId` | `string` | `false` | API リクエスト ID | Header `X-Request-Id` 指定時は一致 |
+| `generatedAt` | `string` | `false` | 生成日時（ISO 8601） | - |
+
+### 7.4 Response Example
+
+#### 7.4.1 正常系（`status: ok`）
+
+```json
+{
+  "data": {
+    "status": "ok",
+    "service": "reco",
+    "version": "0.1.0",
+    "checkedAt": "2026-06-05T12:00:00+09:00"
+  },
+  "meta": {
+    "traceId": "550e8400-e29b-41d4-a716-446655440000",
+    "generatedAt": "2026-06-05T12:00:00+09:00"
+  }
+}
+```
+
+#### 7.4.2 エラー系（認証失敗）
+
+```json
+{
+  "error": {
+    "code": "GRS-AUTH-001",
+    "message": "認証に失敗しました。"
+  },
+  "meta": {
+    "traceId": "550e8400-e29b-41d4-a716-446655440000"
+  }
+}
+```
+
+---
+
+## 8. Error Response仕様
+
+### 8.1 共通形式
+
+API設計方針書 §8.3 に従い、エラー時は `error` + `meta` 構造とする。`data` は返さない。
+
+| 項目 | 型 | 必須 | 内容 |
+| ---- | -- | ---- | ---- |
+| `error.code` | `string` | `true` | `GRS-*` エラーコード |
+| `error.message` | `string` | `true` | 安全なメッセージ |
+| `error.details` | `array` / `object` | `false` | Validation 補足（本 API では通常なし） |
+| `meta.traceId` | `string` | `false` | 横断追跡 ID |
+| `meta.requestId` | `string` | `false` | リクエスト ID |
+
+### 8.2 発生し得るエラーコード
+
+API一覧の主なエラーコード（`GRS-COM-*` / `GRS-REC-*`）および Internal 認証に整合する。
+
+| HTTP Status | error.code | 発生条件 |
+| ----------- | ---------- | -------- |
+| 401 | `GRS-AUTH-001` | Internal API Key 不正 |
+| 401 | `GRS-AUTH-004` | Internal API Key 未指定 |
+| 403 | `GRS-AUTH-002` | 許可されない操作 |
+| 500 | `GRS-COM-999` | 想定外内部エラー |
+| 500 | `GRS-REC-002` | reco 処理失敗（ヘルスチェック処理内） |
+| 503 | `GRS-COM-003` | 一時利用不可（依存不全等） |
+
+api が Public API 向けにエラーを整形する場合の詳細は実装仕様書 Task で扱う。本 API は Internal のため、api 内部ログに `GRS-*` を保持する。
+
+---
+
+## 9. Validation仕様
+
+| 対象 | ルール | 失敗時 |
+| ---- | ------ | ------ |
+| HTTP Method | `GET` のみ | 405（実装 Task で扱う。契約上は想定外） |
+| `X-Internal-Api-Key` | 必須・検証成功 | 401（`GRS-AUTH-001` / `GRS-AUTH-004`） |
+| Path / Query / Body | 本 API ではパラメータ・Body なし | - |
+
+---
+
+## 10. OpenAPI / generated 反映方針
+
+| 項目 | 内容 |
+| ---- | ---- |
+| OpenAPI正本 | `packages/contracts/openapi/internal-reco-api.yaml` |
+| 操作 ID（案） | `getRecoHealth` または `checkRecoHealth`（OpenAPI Task で確定） |
+| Path | `/internal/reco/v1/health` |
+| components schema | `RecoHealthResponse` / `HealthStatus` 等（OpenAPI Task で命名確定） |
+| Orval設定 | リポジトリ正本 `orval.config.ts` |
+| generated出力先（api→reco） | `apps/api/src/generated/reco-client/` |
+
+本 Task では YAML / generated の**実変更は行わない**。本契約仕様書を OpenAPI（internal）Contract Task の入力正本とする。
+
+Contract Gate 通過後に Implementation Task および apps/reco・apps/api 実装 Task を開始する。
+
+---
+
+## 11. 互換性・破壊的変更
+
+| 項目       | 内容 |
+| ---------- | ---- |
+| 破壊的変更 | MVP 初版のためなし |
+| 後方互換性 | `v1` パス固定。フィールド追加は optional で許容 |
+| 判断理由   | 初回 Internal ヘルスチェック契約確定 |
+
+### 11.1 rollout order
+
+- 本契約確定 → `internal-reco-api.yaml` 更新 → Orval 再生成（reco-client）→ apps/api Reco Client 更新 → apps/reco エンドポイント実装
+
+---
+
+## 12. 契約面テスト観点
+
+| No | 観点 | 確認内容 | 種別 |
+| --: | ---- | -------- | ---- |
+| 1 | 正常系 | 有効な `X-Internal-Api-Key` で 200、`data.status: ok`、`data.service: reco` | contract |
+| 2 | auth error | `X-Internal-Api-Key` 欠落・不正で 401 | contract |
+| 3 | trace 伝播 | `X-Trace-Id` 指定時に `meta.traceId` が一致 | contract |
+| 4 | 冪等性 | 同一 Request の繰り返しで副作用なし | contract |
+| 5 | generated client | OpenAPI 生成後、型が Response と一致（`apps/api` reco-client） | typecheck |
+
+実装結合・依存障害シミュレーションは実装仕様書・単体テスト Task で扱う。
+
+---
+
+## 13. 変更履歴
+
+| 日付 | 変更内容 | 関連Issue / PR |
+| ---- | -------- | -------------- |
+| 2026-06-05 | 初版（契約面のみ。Phase1 1a） | #392 |
+
+---
+
+## 14. 未決事項
+
+### 14.1 確定済み（本書へ反映済み）
+
+| No | 論点 | 確定内容 | 反映箇所 |
+| --: | ---- | -------- | -------- |
+| 1 | Endpoint / Method | `GET /internal/reco/v1/health`（API一覧・API設計方針書 §29.2） | §4 |
+| 2 | Provider / Consumer | Provider: `apps/reco` エンドポイント層、Consumer: `apps/api` | §4、§5.4 |
+| 3 | Request Body | なし（GET） | §6.4 |
+| 4 | 認証 | Internal API Key 必須（API設計方針書 §11.3） | §6.1、§9 |
+
+### 14.2 未決（人間判断待ち）
+
+| No | 論点 | 判断が必要な理由 | 判断者 | 期限 | 備考 | 追跡 Issue |
+| --: | ---- | ---------------- | ------ | ---- | ---- | ---------- |
+| 1 | `degraded` / `unavailable` の判定条件 | MVP 初版は `ok` のみ必須としたが、依存チェック（DB 等）の範囲は実装判断が必要 | Human | - | 実装仕様書 Task で詳細化 | - |
+| 2 | `data.version` の必須化 | デプロイ追跡に有用だが MVP で必須とするか未確定 | Human | - | 現状 optional | - |
+
+OpenAPI（`internal-reco-api.yaml`）への機械可読反映は **別 Contract Task** とする。
+
+---
+
+## 15. 関連資料
+
+| 種別 | パス / URL | 用途 |
+| ---- | ---------- | ---- |
+| API一覧 | `docs/05_アプリケーション設計/アプリ/api/API一覧.md` | API-INT-001 行 |
+| API設計方針書 | `docs/05_アプリケーション設計/アプリ/api/API設計方針書.md` | Internal API / Response 形式 |
+| エラーコード定義書 | `docs/05_アプリケーション設計/アプリ/エラーコード定義書.md` | GRS-* |
+| 認証・認可方針書 | `docs/05_アプリケーション設計/基盤/認証・認可方針書.md` | Internal API Key |
+| ログ・Observability設計書 | `docs/05_アプリケーション設計/アプリ/ログ・Observability設計書.md` | access_log / metric |
+| インターフェース一覧 | `docs/05_アプリケーション設計/アプリ/インターフェース一覧.md` | IF-INT-001 |
+| 機能×モジュール対応表 | `docs/05_アプリケーション設計/アプリ/機能×モジュール対応表.md` | MOD-API-005 |
+| 参考（同一群） | `docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md` | Internal API 契約スタイル |
+| Task Definition | `prompts/definitions/tasks/api-int-001-reco-health-check/api-contract-spec.yaml` | #392 scope |
+| Epic Definition | `prompts/definitions/epics/api-int-001-reco-health-check/epic.yaml` | #391 scope |
+
+---
+
+## 16. レビュー観点
+
+- API契約（Request / Response / Error / Validation）が明確で、OpenAPI（internal）Task の入力として十分か
+- API一覧の API-INT-001（endpoint / Method GET / Internal / Provider reco・Consumer api / MVP）と一致しているか
+- API設計方針書 §11.3（Internal 保護）および §8.2（data + meta）と矛盾していないか
+- Provider（apps/reco エンドポイント層）/ Consumer（apps/api）の I/F 境界が明確か
+- 推薦パイプライン・MOD-RECO 実装詳細を含んでいないか
+- `packages/contracts/openapi/internal-reco-api.yaml` への反映方針が明確か（本 Task でファイル未変更）
+- secret / `.env` 実値が含まれていないか
+
+### 16.1 Human Review で確認してほしいこと
+
+- 正式 Endpoint（`GET /internal/reco/v1/health`）と api→reco I/F 境界
+- Internal API Key をヘルスチェックでも必須とする方針
+- Response `data.status` の値域（`ok` / `degraded` / `unavailable`）と MVP での必須範囲
+- `data.version` を optional とした方針
+- OpenAPI Contract Task への分離方針（`internal-reco-api.yaml`）
+
+---
+
+## 17. 備考
+
+- 本書は `prompts/templates/docs/api-contract-spec.md` に準拠した Phase1 ①（1a）成果物である。
+- reco を FastAPI 等の常駐サービスとして動かす前提（API一覧 備考）に整合する。
+- 本 API は API-INT-002（推薦実行）の前提となる接続確認用途であり、推薦ロジックは実行しない。

--- a/prompts/definitions/reviews/api-int-001-reco-health-check/pr-review.yaml
+++ b/prompts/definitions/reviews/api-int-001-reco-health-check/pr-review.yaml
@@ -18,7 +18,7 @@ branch:
   worktree_required: false
 
 target:
-  pr: null
+  pr: 393
   issue: 392
   task_definition: "prompts/definitions/tasks/api-int-001-reco-health-check/api-contract-spec.yaml"
   source_branch: "docs/task-392-api-int-001-reco-health-check-api-contract-spec"
@@ -70,7 +70,7 @@ input:
     number: 392
     required: true
   pr:
-    number: null
+    number: 393
     required: true
   diff:
     required: true

--- a/prompts/definitions/reviews/api-int-001-reco-health-check/pr-review.yaml
+++ b/prompts/definitions/reviews/api-int-001-reco-health-check/pr-review.yaml
@@ -1,0 +1,322 @@
+schema_version: "1.0"
+definition_type: "review"
+
+review:
+  id: "review-api-int-001-reco-health-check-api-contract-spec-pr"
+  title: "API-INT-001 RecoヘルスチェックAPI契約仕様書 PRレビュー"
+  summary: "API-INT-001（Recoヘルスチェック / Internal API）API契約仕様書作成 Task（api-contract-spec.yaml）の PR を AI Review する"
+  type: "task_pr_review"
+  status: "ready"
+
+work_mode: "ai-agent"
+
+branch:
+  no_branch: true
+  name: null
+  base: null
+  target: null
+  worktree_required: false
+
+target:
+  pr: null
+  issue: 392
+  task_definition: "prompts/definitions/tasks/api-int-001-reco-health-check/api-contract-spec.yaml"
+  source_branch: "docs/task-392-api-int-001-reco-health-check-api-contract-spec"
+  target_branch: "feature/epic-391-int-001-reco-health-check"
+  parent_epic_issue: "[Epic]API-INT-001:Recoヘルスチェック"
+  parent_epic_branch: "feature/epic-391-int-001-reco-health-check"
+
+commands:
+  primary: "/review-pr"
+  allowed:
+    - "/review-pr"
+    - "/summarize-work"
+  next:
+    approve_for_human_review: "Human Review"
+    request_changes: "/fix-review-comments"
+    needs_human_decision: "Human Decision"
+    split_required: "/start-task"
+    blocked: null
+
+agent:
+  primary: "reviewer-ai"
+  support:
+    - "support-ai"
+  specialist:
+    docs: "docs-reviewer-ai"
+    test: null
+    contract: "contract-ai"
+    security: null
+  next:
+    fixer: "fixer-ai"
+    human: "human-reviewer"
+
+review_scope:
+  docs: true
+  source: false
+  tests: false
+  api_contract: true
+  db: true
+  generated: true
+  cicd: false
+  security: true
+  project_operation: true
+
+input:
+  task_definition:
+    path: "prompts/definitions/tasks/api-int-001-reco-health-check/api-contract-spec.yaml"
+    required: true
+  issue:
+    number: 392
+    required: true
+  pr:
+    number: null
+    required: true
+  diff:
+    required: true
+    compare_with: "feature/epic-391-int-001-reco-health-check"
+  docs:
+    - path: "docs/06_実装設計/api/API-INT-001_RecoヘルスチェックAPI契約仕様書.md"
+      required: true
+      purpose: "作成成果物（契約面）の内容確認"
+    - path: "docs/05_アプリケーション設計/アプリ/api/API一覧.md"
+      required: true
+      purpose: "API-INT-001 行（endpoint / Method / API種別 Internal / MVP対象 / 関連モジュール）との整合確認"
+    - path: "docs/05_アプリケーション設計/アプリ/api/API設計方針書.md"
+      required: true
+      purpose: "Internal API の URL / Method / 認証 / Error 形式方針との整合確認"
+    - path: "docs/05_アプリケーション設計/アプリ/エラーコード定義書.md"
+      required: true
+      purpose: "Error Response とエラーコード参照の整合確認"
+    - path: "docs/05_アプリケーション設計/アプリ/ログ・Observability設計書.md"
+      required: true
+      purpose: "access_log / metric / trace_id 方針との整合確認"
+    - path: "docs/05_アプリケーション設計/アプリ/機能×モジュール対応表.md"
+      required: false
+      purpose: "API-INT-001 / MOD-API-005 の対応関係との整合確認"
+    - path: "docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md"
+      required: false
+      purpose: "同一 Internal API 群の契約スタイル・認証・Error 形式との整合確認"
+  files: []
+  test_results:
+    required: true
+    source: "pr_body"
+  ci_results:
+    required: false
+    source: "not_required"
+  templates:
+    review_outputs:
+      pr_comment: "prompts/templates/review/ai-review-comment.md"
+      slack: "prompts/templates/slack/ai-review-result.md"
+    deliverables:
+      - path: "prompts/templates/docs/api-contract-spec.md"
+        required: true
+        purpose: "Task成果物が api-contract-spec.md に沿って作成されているか確認するため"
+        applies_to:
+          - "docs/06_実装設計/api/API-INT-001_RecoヘルスチェックAPI契約仕様書.md"
+
+review_points:
+  common:
+    - "Task Definition（api-contract-spec.yaml）の scope を満たしているか"
+    - "out_of_scope（API-INT-002 / Reco モジュール本体 / OpenAPI / 実装 / 他API）の変更が混在していないか"
+    - "acceptance_criteria を満たしているか"
+    - "PR本文に変更内容、検証結果、未実施事項が記載されているか"
+    - "Human Review観点が明記されているか"
+    - "Task Branch から develop へ直接 PR していないか（target は親 Epic Branch）"
+    - "Task PR で Closes #<Task Issue番号> を使っていないか（Related to を使用）"
+  docs:
+    - "指定された文書テンプレート（api-contract-spec.md）に沿って作成されているか"
+    - "API契約仕様書が docs/06_実装設計/api/API-INT-001_RecoヘルスチェックAPI契約仕様書.md に作成されているか"
+    - "実装面（api-implementation-spec.md 相当の処理フロー・MOD-RECO 詳細）が混入していないか"
+    - "API基本情報（API ID / API種別 Internal / Method GET / Endpoint /internal/reco/v1/health / Provider apps/reco / Consumer apps/api / MVP対象）が記載されているか"
+    - "Request / Response / Error Response / Validation が Contract Gate / OpenAPI Task の入力として確定可能な粒度で記載されているか"
+    - "Request Body がないこと（GET ヘルスチェック）が明記されているか"
+    - "Response Body が Reco稼働状態として整理されているか"
+    - "ログ・Observability設計書と trace_id / access_log / reco_health_check_count 方針が整合しているか"
+    - "用語揺れがないか"
+    - "Notion 転記を想定した Markdown 体裁になっているか"
+    - "Task タイトル・成果物ファイル名が §15.2 に従っているか"
+  source: []
+  tests:
+    - "docs 作成 Task として必要な manual check が記載されているか"
+    - "未実施テストの理由が PR 本文に記載されているか"
+  api_contract:
+    - "OpenAPI（internal-reco-api.yaml）変更が混在していないか（混在する場合は Contract Task として分離）"
+    - "Orval 再生成が混在していないか"
+    - "generated reco-client 変更が混在していないか"
+    - "provider（apps/reco エンドポイント層）/ consumer（apps/api）影響が整理されているか"
+    - "OpenAPI / Orval / generated の扱いと Contract Task 分離方針が記載されているか"
+    - "破壊的変更有無と後方互換性が明記されているか"
+  db:
+    - "DB schema 変更が混在していないか"
+    - "migration 変更が混在していないか"
+  generated:
+    - "generated ファイルを手動編集していないか"
+  cicd: []
+  security:
+    - "secret や .env 実値が含まれていないか"
+    - "Internal API Key の扱いが方針として記載されているか（実値を含まないこと）"
+  branch:
+    - "Task Branch から develop へ直接 PR していないか"
+    - "PR target が親 Epic Branch（feature/epic-391-int-001-reco-health-check）であるか"
+    - "Task PR で Related to #392 が使われているか"
+    - "Task PR で Closes #392 を使っていないか"
+  project:
+    - "レビュー結果に応じた Status 更新意図が明確か"
+  epic_scope:
+    - "PR差分が親Epic [Epic]API-INT-001:Recoヘルスチェック の epic_scope.allowed_paths 内に収まっているか"
+    - "epic_scope.forbidden_paths（apps/reco/src/reco/application / apps/reco/src/reco/domain / apps/reco/src/reco/pipeline / apps/api/src/app / apps/web / openapi/** / db）への変更が混入していないか"
+
+acceptance_check:
+  use_task_acceptance_criteria: true
+  additional_criteria:
+    - "PR本文に実施済み検証と未実施テストの理由が記載されている"
+    - "Human Reviewで確認してほしい事項が明記されている"
+    - "AI Review結果をPRコメントに記録できる形式になっている"
+    - "Task Definition で文書テンプレート（api-contract-spec.md）が指定されているため、成果物が契約面テンプレートに沿っている"
+    - "親Epic の epic_scope.allowed_paths から外れる差分がない"
+    - "OpenAPI / generated 変更を Contract Task として分離する方針が明記されている"
+
+result_policy:
+  approve_for_human_review:
+    conditions:
+      - "acceptance_criteria を満たしている"
+      - "修正必須事項がない"
+      - "scope 外変更がない"
+      - "epic_scope.allowed_paths から外れる差分がない"
+      - "Human Review で確認すべき事項が整理されている"
+  request_changes:
+    conditions:
+      - "同一 Branch で修正可能な docs 不備がある"
+      - "PR 本文に必要情報が不足している"
+      - "検証結果または未実施理由が不足している"
+      - "テンプレート（api-contract-spec.md）準拠が一部欠落している"
+  needs_human_decision:
+    conditions:
+      - "ヘルスチェック Response Body の status / checks 範囲判断が必要"
+      - "Internal API の認証要否（ヘルスチェック）の判断が必要"
+      - "scope 外変更を同一 PR に含めるべきか判断が必要"
+      - "未実施テストを許容して Human Review へ進めてよいか判断が必要"
+  split_required:
+    conditions:
+      - "OpenAPI（internal）変更が混在している（Contract Task として分離）"
+      - "Orval / generated 変更が混在している（Contract Task として分離）"
+      - "Reco モジュール（MOD-RECO-001 等）本体の変更が混在している"
+      - "API-INT-002 の仕様変更が混在している"
+      - "epic_scope.allowed_paths から外れる差分がある"
+      - "別 Issue 化すべき設計変更が混在している"
+  blocked:
+    conditions:
+      - "PR diff を確認できない"
+      - "Task Definition が存在しない"
+      - "Issue と PR の対応が不明"
+      - "secret や .env 実値の混入が疑われる"
+      - "Task 成果物に指定された文書テンプレート（api-contract-spec.md）を確認できない"
+      - "親 Epic Issue / Branch が存在しない"
+
+status_policy:
+  current_status: "AI Review"
+  on_approve: "Human Review"
+  on_request_changes: "In Progress"
+  on_needs_human_decision: "Human Review"
+  on_split_required: "In Progress"
+  on_blocked: "In Progress"
+
+outputs:
+  pr_comment_template: "prompts/templates/review/ai-review-comment.md"
+  slack_template: "prompts/templates/slack/ai-review-result.md"
+  update_pr_body: false
+  create_follow_up_issue: false
+  ai_logs:
+    required: false
+    path: null
+
+project:
+  project_name: "Gift Recommendation Service MVP Cycle 3"
+  fields:
+    phase: "06_実装設計"
+    status: "AI Review"
+    priority: "high"
+    planned_start: null
+    due_date: null
+
+issue:
+  unit: "task"
+  type: "docs"
+  area: "api"
+
+dependencies:
+  epics: []
+  issues: []
+  prs: []
+  tasks:
+    - "prompts/definitions/tasks/api-int-001-reco-health-check/api-contract-spec.yaml"
+  blocking: false
+
+parallel_control:
+  depends_on: []
+  blocks: []
+  exclusive_files: []
+  conflict_risk: "low"
+  generated_impact: false
+  contract_impact: true
+  db_impact: false
+
+test_policy:
+  required:
+    - "AI Review"
+    - "PR diff check"
+    - "docs review"
+    - "API contract impact check"
+    - "secret check"
+  commands: []
+  manual_checks:
+    - "Task Definitionのacceptance_criteriaを満たしているか確認する"
+    - "PR本文に検証結果・未実施理由・Human Review観点が記載されているか確認する"
+    - "OpenAPI / Orval / generated 変更が混在していないか確認する"
+    - "Task成果物が api-contract-spec.md の章構成に沿っているか確認する"
+  not_required:
+    - "unit test"
+  skip_reason:
+    "unit test": "Review Definitionはレビュー条件であり、実装テストを直接実行する作業定義ではないため"
+
+operation_logging:
+  level: "standard"
+  ai_logs:
+    intake: false
+    incidents: false
+    cross_cutting: true
+    experiments: false
+  reason: "本 Task は OpenAPI（internal）/ reco-client への横断影響可能性があるため、cross-cutting 影響が判明した場合は ai-logs/cross-cutting へ記録余地を残す。通常PRレビュー結果はPRコメントを正本とする。"
+
+risk_points:
+  - "API-INT-001 契約仕様書 Task に OpenAPI / Orval / generated 変更が混在する可能性"
+  - "ヘルスチェック Response の粒度を API-INT-002 相当まで詳細化しすぎる可能性"
+  - "Internal API の認証・認可方針をAIだけで確定してしまう可能性"
+
+human_decision_points:
+  - "ヘルスチェック Response Body の status / checks / version 確定"
+  - "Internal API Key をヘルスチェックでも必須とするかの最終確認"
+  - "未実施テストの理由を許容して Human Review へ進めてよいか"
+
+stop_conditions:
+  - "PR が存在しない場合"
+  - "Task Definition が存在しない場合"
+  - "Issue と PR の対応が不明な場合"
+  - "diff を確認できない場合"
+  - "Reco モジュール本体（apps/reco/src/reco/application 等）の変更が混在している場合"
+  - "OpenAPI（internal）変更が混在している場合（Contract Task として分離）"
+  - "DB schema 変更が混在している場合"
+  - "generated ファイルの手動編集が疑われる場合"
+  - "secret や .env 実値の混入が疑われる場合"
+  - "Human Review を省略する前提になっている場合"
+  - "AI が merge 判断を行う必要がある場合"
+  - "指定された文書テンプレート（api-contract-spec.md）が存在しない場合"
+  - "PR差分が親Epic の epic_scope.allowed_paths から外れている場合"
+
+notes:
+  - "本Taskは Phase1 1a（契約仕様書 docs）のため、source code 変更は原則 scope 外とする"
+  - "対応 Task Definition: prompts/definitions/tasks/api-int-001-reco-health-check/api-contract-spec.yaml"
+  - "対応 Epic Definition: prompts/definitions/epics/api-int-001-reco-health-check/epic.yaml"
+  - "OpenAPI / Orval / generated 変更は横断 Epic #367 等の Contract Task として分離する"
+  - "review.target.pr は PR 作成後に更新する"

--- a/prompts/definitions/tasks/api-int-001-reco-health-check/api-contract-spec.yaml
+++ b/prompts/definitions/tasks/api-int-001-reco-health-check/api-contract-spec.yaml
@@ -1,0 +1,326 @@
+schema_version: "1.0"
+definition_type: "task"
+
+task:
+  id: "task-api-int-001-reco-health-check-api-contract-spec"
+  title: "API-INT-001:RecoヘルスチェックAPI契約仕様書作成"
+  summary: "API-INT-001（Recoヘルスチェック / Internal API、`GET /internal/reco/v1/health`）のAPI契約仕様書（API-INT-001_RecoヘルスチェックAPI契約仕様書.md）を、API設計方針書・API一覧・エラーコード定義書・ログ・Observability設計書に基づき、prompts/templates/docs/api-contract-spec.md に準拠して作成する（契約面のみ。実装面・apps/reco実装は対象外）。"
+
+work_mode: "ai-agent"
+
+parent:
+  epic_issue: "[Epic]API-INT-001:Recoヘルスチェック"
+  epic_issue_number: 391
+  epic_branch: "feature/epic-391-int-001-reco-health-check"
+  related_issues: []
+  related_prs: []
+
+commands:
+  primary: "/start-task"
+  allowed:
+    - "/start-task"
+    - "/work-issue"
+    - "/create-pr"
+    - "/fix-review-comments"
+    - "/summarize-work"
+  next:
+    success: "/work-issue"
+    review_fix: "/fix-review-comments"
+    blocked: null
+
+agent:
+  primary: "worker-ai"
+  support:
+    - "orchestrator-ai"
+    - "support-ai"
+    - "contract-ai"
+  review:
+    - "reviewer-ai"
+    - "docs-reviewer-ai"
+    - "contract-ai"
+
+background: |
+  06_実装設計において、apps/reco エンドポイント層実装・OpenAPI（internal）定義・apps/api 側 reco-client 利用・Contract Task 化の前提となる **API契約仕様書（契約面）** を作成する。
+  本Taskは API一覧の API-INT-001（Recoヘルスチェック / Internal API）を対象とし、api→reco 間の Request / Response / Error / Validation / 互換性 / OpenAPI反映方針（記載のみ）を整理する。
+  Provider は apps/reco のエンドポイント層（`apps/reco/src/reco/api/**`）、Consumer は apps/api（MOD-API-005 Reco Client 等）とする。
+  ヘルスチェックは推薦パイプラインを実行しない軽量 API であるため、API-INT-002 契約仕様書より簡素な契約面とする。
+  親 Epic（[Epic]API-INT-001:Recoヘルスチェック）の epic_scope に従い、本Taskは契約 docs のみを作成し、apps/reco 実装・OpenAPI ファイル変更は行わない。
+
+objective: |
+  API-INT-001（Recoヘルスチェック / Internal API、`GET /internal/reco/v1/health`）について、Contract Gate および後続 Implementation Task / OpenAPI Contract Task が参照可能な粒度の **API契約仕様書（契約面のみ）** を作成する。
+  成果物は prompts/templates/docs/api-contract-spec.md に準拠し、実装面（`api-implementation-spec.md`）の章は含めない。
+  OpenAPI 正本パス（`packages/contracts/openapi/internal-reco-api.yaml`）および Orval / generated 方針は契約仕様書内に **方針として記載** するが、本Taskでは当該ファイルを変更しない。
+
+scope:
+  - "API-INT-001（Recoヘルスチェック / Internal API）のAPI契約仕様書を新規作成する（成果物ファイル名: API-INT-001_RecoヘルスチェックAPI契約仕様書.md）"
+  - "API基本情報を定義する（API ID / API種別 Internal API / Method GET / Endpoint /internal/reco/v1/health / Provider apps/reco エンドポイント層 / Consumer apps/api / 認証要否 / 冪等性 / MVP対象）"
+  - "Request Header / Path Parameters / Query Parameters / Request Bodyを整理する（ヘルスチェックのため Request Body なし）"
+  - "Response Header / Status Code / Response Bodyを整理する（Reco稼働状態）"
+  - "Error Response仕様を整理する（GRS-COM-* / GRS-REC-* / GRS-AUTH-* 等）"
+  - "バリデーション仕様を整理する"
+  - "契約面における trace_id / ログ・メトリクス対象項目（Request/Response に含める識別子の範囲）を整理する"
+  - "契約面における provider（apps/reco エンドポイント層）/ consumer（apps/api）の I/F 境界を整理する"
+  - "OpenAPI / Orval / generated 反映方針を整理する（正本: packages/contracts/openapi/internal-reco-api.yaml、generated: apps/api/src/generated/reco-client/ 等。ファイル変更は本Task外）"
+  - "互換性・破壊的変更・rollout order を整理する"
+  - "契約面テスト観点（api-contract-spec.md §12）を整理する"
+  - "未決事項・人間判断が必要な事項を明記する"
+
+out_of_scope:
+  - "API-INT-002（Reco推薦実行）の仕様・契約仕様書変更"
+  - "API-PUB-001（Public API / APIヘルスチェック）の仕様・契約仕様書作成"
+  - "prompts/templates/docs/api-implementation-spec.md に準拠する実装面章（処理フロー・Mermaid、内部DTOマッピング、provider/consumer 実装影響、実装結合テスト観点、非機能の実装詳細）"
+  - "OpenAPI定義ファイル（packages/contracts/openapi/internal-reco-api.yaml）の作成・更新"
+  - "Orval設定ファイル（orval.config.ts）の作成・更新"
+  - "generated API client（apps/api/src/generated/reco-client/ 等）の再生成"
+  - "apps/api の実装"
+  - "apps/web の実装"
+  - "apps/reco の実装（エンドポイント層・application 層を含む）"
+  - "Recoモジュール本体（MOD-RECO-001〜029）の設計・実装"
+  - "DB schema変更"
+  - "DDL作成・変更"
+  - "認証・認可方式そのものの変更"
+  - "API一覧全体の再設計"
+  - "画面仕様書の作成"
+  - "他 API（API-PUB-002〜008 / API-INT-002 / API-EXT-*）の契約仕様書作成"
+
+input:
+  docs:
+    - path: "docs/05_アプリケーション設計/アプリ/api/API設計方針書.md"
+      required: true
+      purpose: "Internal API の URL 設計、HTTP Method、認証、エラー形式、バージョニング等の API 設計方針を確認するため"
+    - path: "docs/05_アプリケーション設計/アプリ/api/API一覧.md"
+      required: true
+      purpose: "API-INT-001 の endpoint、API種別（Internal API）、呼び出し元（api）/ 呼び出し先（reco）、MVP対象を確認するため"
+    - path: "docs/05_アプリケーション設計/アプリ/エラーコード定義書.md"
+      required: true
+      purpose: "Internal API の Error Response、HTTP Status、GRS-COM-* / GRS-REC-* 等を確認するため"
+    - path: "docs/05_アプリケーション設計/アプリ/ログ・Observability設計書.md"
+      required: true
+      purpose: "API-INT-001 の trace_id / access_log / metric（reco_health_check_count）対象を契約仕様書へ反映するため"
+    - path: "docs/05_アプリケーション設計/基盤/認証・認可方針書.md"
+      required: true
+      purpose: "Internal API の認証要否、認可条件、サービス間アクセス制御方針を確認するため"
+    - path: "docs/05_アプリケーション設計/アプリ/機能一覧.md"
+      required: true
+      purpose: "Reco稼働確認が対応する機能と MVP 対象範囲を確認するため"
+    - path: "docs/05_アプリケーション設計/アプリ/モジュール一覧.md"
+      required: true
+      purpose: "MOD-API-005（Reco Client）/ reco エンドポイント層との責務境界を確認するため"
+    - path: "docs/05_アプリケーション設計/アプリ/reco/Recoモジュール一覧.md"
+      required: false
+      purpose: "reco エンドポイント層と推薦ロジック層の境界を確認するため"
+    - path: "docs/05_アプリケーション設計/アプリ/機能×モジュール対応表.md"
+      required: false
+      purpose: "API-INT-001 / MOD-API-005 の接続を確認するため"
+    - path: "docs/05_アプリケーション設計/アプリ/インターフェース一覧.md"
+      required: false
+      purpose: "IF-INT-001 と API-INT-001 の対応を確認するため"
+    - path: "docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md"
+      required: false
+      purpose: "同一 Internal API 群の契約仕様書スタイル・認証・Error 形式の参考とするため"
+  templates:
+    - path: "prompts/templates/docs/api-contract-spec.md"
+      required: true
+      purpose: "API契約仕様書（契約面のみ）を標準フォーマットで作成するため"
+      applies_to:
+        - "docs/06_実装設計/api/API-INT-001_RecoヘルスチェックAPI契約仕様書.md"
+  files: []
+  issues: []
+  prs: []
+  openapi:
+    path: "packages/contracts/openapi/internal-reco-api.yaml"
+    required: false
+    purpose: "OpenAPI 正本パスを契約仕様書 §10 に記載するため（本Taskではファイル変更しない。方針・参照のみ）"
+
+output:
+  docs:
+    - path: "docs/06_実装設計/api/API-INT-001_RecoヘルスチェックAPI契約仕様書.md"
+      action: "create"
+      required: true
+      template: "prompts/templates/docs/api-contract-spec.md"
+  files: []
+  tests: []
+  generated:
+    expected: false
+    paths: []
+    handling: "none"
+  logs:
+    ai_logs_required: false
+    path: null
+
+deliverables:
+  - "API-INT-001（Recoヘルスチェック）API契約仕様書（ファイル名: API-INT-001_RecoヘルスチェックAPI契約仕様書.md）"
+  - "Request / Response / Error Response 定義（契約面）"
+  - "Validation 仕様"
+  - "trace_id / ログ・メトリクス対象（契約面で露出する項目）"
+  - "provider（apps/reco エンドポイント層）/ consumer（apps/api）の I/F 境界整理"
+  - "OpenAPI（internal-reco-api.yaml）/ Orval / generated 反映方針（記載のみ）"
+  - "互換性・破壊的変更・契約面テスト観点"
+  - "未決事項・人間判断事項の整理"
+
+acceptance_criteria:
+  - "docs/06_実装設計/api/API-INT-001_RecoヘルスチェックAPI契約仕様書.md が作成されている"
+  - "prompts/templates/docs/api-contract-spec.md の契約面章に準拠している（api-implementation-spec.md の実装面章を含んでいない）"
+  - "API設計方針書と矛盾する URL、HTTP Method、認証、Error 形式を定義していない"
+  - "API一覧の API-INT-001 と矛盾する endpoint、HTTP Method、API種別（Internal API）、呼び出し元（api）/ 呼び出し先（reco）、MVP対象を定義していない"
+  - "Provider が apps/reco（エンドポイント層）、Consumer が apps/api であることが明記されている"
+  - "Request Body がないこと（GET ヘルスチェック）が明記されている"
+  - "Response Body が Reco稼働状態として整理されている"
+  - "Error Response とエラーコードがエラーコード定義書と整合している"
+  - "trace_id / access_log / metric（reco_health_check_count）方針がログ・Observability設計書と整合している（契約面の露出範囲に限定）"
+  - "OpenAPI 正本パスとして packages/contracts/openapi/internal-reco-api.yaml が記載されている"
+  - "OpenAPI / Orval / generated のファイル変更を本Taskに含めていない"
+  - "apps/reco / apps/api のソースコード変更を本Taskに含めていない"
+  - "処理フロー・内部DTOマッピング・実装結合テスト等の実装面詳細を契約仕様書に混入していない"
+  - "未決事項がある場合、未決事項として明記されている"
+  - "secret、APIキー、.env 実値、接続文字列の実値を含んでいない"
+  - "Human Review で確認してほしい事項が明記されている"
+
+branch:
+  no_branch: false
+  name: "docs/task-392-api-int-001-reco-health-check-api-contract-spec"
+  base: "feature/epic-391-int-001-reco-health-check"
+  target: "feature/epic-391-int-001-reco-health-check"
+  worktree_required: false
+
+project:
+  project_name: "Gift Recommendation Service MVP Cycle 3"
+  fields:
+    phase: "06_実装設計"
+    status: "Todo"
+    priority: "high"
+    planned_start: null
+    due_date: null
+
+issue:
+  unit: "task"
+  type: "docs"
+  area: "api"
+
+dependencies:
+  epics: []
+  issues: []
+  prs: []
+  tasks:
+    - "API設計方針書が作成済みであること"
+    - "API一覧が作成済みであること"
+    - "エラーコード定義書が作成済みであること"
+    - "ログ・Observability設計書が作成済みであること"
+  blocking: false
+
+parallel_control:
+  depends_on: []
+  blocks:
+    - "API-INT-001 実装面仕様書 Task（api-implementation-spec 準拠）"
+    - "API-INT-001 OpenAPI（internal）Contract Task"
+    - "API-INT-001 reco エンドポイント実装 Task"
+  exclusive_files:
+    - "docs/06_実装設計/api/API-INT-001_RecoヘルスチェックAPI契約仕様書.md"
+  conflict_risk: "low"
+  generated_impact: false
+  contract_impact: true
+  db_impact: false
+
+test_policy:
+  required:
+    - "docs review"
+    - "markdown format check"
+    - "template conformity check"
+    - "api design consistency check"
+    - "api list consistency check"
+    - "error response consistency check"
+    - "contract impact check"
+    - "secret check"
+  commands:
+    - "markdownlint docs/06_実装設計/api/API-INT-001_RecoヘルスチェックAPI契約仕様書.md"
+  manual_checks:
+    - "api-contract-spec.md の章構成（契約面のみ）に準拠していることを確認する"
+    - "api-implementation-spec.md の章（処理フロー・内部DTOマッピング等）が混入していないことを確認する"
+    - "API設計方針書と矛盾がないことを確認する"
+    - "API一覧の API-INT-001 と endpoint / method / API種別（Internal API）/ 呼び出し元・呼び出し先 / MVP対象 が一致していることを確認する"
+    - "Provider（apps/reco エンドポイント層）/ Consumer（apps/api）が明記されていることを確認する"
+    - "エラーコード定義書と Error Response が整合していることを確認する"
+    - "OpenAPI 正本パス（internal-reco-api.yaml）が記載され、本Taskで OpenAPI ファイルを変更していないことを確認する"
+    - "apps/reco / apps/api の実装変更を本Taskに含めていないことを確認する"
+    - "secret、APIキー、.env 実値、接続文字列の実値が含まれていないことを確認する"
+  not_required:
+    - "unit test"
+    - "integration test"
+    - "e2e test"
+    - "contract test"
+    - "typecheck"
+    - "build"
+  skip_reason:
+    "unit test": "契約 docs 作成 Task であり、source code 変更を含まないため対象外"
+    "integration test": "契約 docs 作成 Task であり、実装変更を含まないため対象外"
+    "e2e test": "契約 docs 作成 Task であり、画面・API 実装を含まないため対象外"
+    "contract test": "OpenAPI 定義・provider 実装・consumer 実装・generated 変更を含まないため対象外。ただし contract impact check は必須確認とする"
+    "typecheck": "source code 変更を含まないため対象外"
+    "build": "source code 変更を含まないため対象外"
+
+review:
+  human_review_required: true
+  ai_review_required: true
+  review_points:
+    - "API契約仕様書として粒度が過不足ないか（契約面に限定されているか）"
+    - "API一覧の API-INT-001 と内容が整合しているか"
+    - "API設計方針書と URL、Method、認証、Error 形式が整合しているか"
+    - "Provider（apps/reco エンドポイント層）/ Consumer（apps/api）の I/F 境界が明確か"
+    - "実装面（処理フロー・内部DTO・実装テスト）が契約仕様書に混入していないか"
+    - "OpenAPI（internal-reco-api.yaml）変更が Contract Task として分離されているか"
+    - "親 Epic epic_scope（apps/reco 実装なし）と本Task差分が整合しているか"
+    - "未決事項が隠れずに明記されているか"
+    - "secret や .env 実値が含まれていないか"
+  specialist_reviews:
+    docs: true
+    test: false
+    contract: true
+    security: true
+
+operation_logging:
+  level: "standard"
+  ai_logs:
+    intake: false
+    incidents: true
+    cross_cutting: true
+    experiments: false
+  reason: "通常の契約 docs 作成作業は ai-logs に保存しない。ただし、必須 input 不足、作業停止、OpenAPI / Orval / generated など横断影響が判明した場合は、必要に応じて incident または cross-cutting として記録する。"
+
+risk_points:
+  - "API一覧とヘルスチェック Response の粒度が一致しない可能性がある"
+  - "Internal API の認証要否（ヘルスチェックで Key 必須とするか）の判断が必要になる可能性がある"
+  - "契約 docs 作成中に OpenAPI（internal-reco-api.yaml）変更が必要と判明する可能性がある"
+  - "Provider（apps/reco エンドポイント層）と Consumer（apps/api / MOD-API-005）の責務境界が曖昧になる可能性がある"
+  - "認証・認可仕様が未確定の場合、契約仕様の確定が止まる可能性がある"
+
+human_decision_points:
+  - "API-INT-001 の正式 Endpoint（`GET /internal/reco/v1/health`）と api→reco の I/F 境界を確認する"
+  - "Provider を apps/reco エンドポイント層、Consumer を apps/api とする方針を確認する"
+  - "ヘルスチェック成功時の Response Body 項目（status / version / checks 等）の最終範囲を確認する"
+  - "Internal API Key をヘルスチェックでも必須とするか確認する"
+  - "OpenAPI（internal-reco-api.yaml）/ Orval / generated 更新を後続 Contract Task として分離するか確認する"
+
+stop_conditions:
+  - "必須 `input.docs` が存在しない場合"
+  - "必須 `input.templates` が存在しない場合"
+  - "必須 `input.docs` 間に矛盾があり、AI Agent だけで判断できない場合"
+  - "API一覧に API-INT-001（Recoヘルスチェック）が存在しない場合"
+  - "正式 Endpoint、HTTP Method、API種別が確定できない場合"
+  - "OpenAPI 定義ファイル（internal-reco-api.yaml）の作成・更新が必要になった場合（Contract Task として分離）"
+  - "Orval 再生成が必要になった場合（Contract Task として分離）"
+  - "generated ファイルの手動編集が必要に見える場合"
+  - "apps/reco または apps/api の実装変更が必要になった場合"
+  - "DB schema 変更が必要になった場合"
+  - "認証・認可仕様変更が必要になった場合"
+  - "secret や .env 実値を扱う必要が出た場合"
+  - "scope 外の実装作業が必要になった場合"
+  - "本Task差分が親 Epic epic_scope.allowed_paths から外れた場合（apps/reco 実装・OpenAPI ファイル変更の混入）"
+
+notes:
+  - "本Taskは API-INT-001 の **契約面** 専用 Task である（Phase1 1a）。構造の参考は prompts/definitions/tasks/api-int-002-reco-recommendation-run/api-contract-spec.yaml および docs/06_実装設計/api/API-INT-002_Reco推薦実行API契約仕様書.md とする。"
+  - "実装面は prompts/templates/docs/api-implementation-spec.md 準拠の別 Task（api-implementation-spec.yaml 等）で作成する。"
+  - "OpenAPI、Orval、generated、apps/reco 実装、apps/api 実装は本Taskでは扱わない。必要になった場合は Contract Task または Implementation Task として分離する。"
+  - "OpenAPI 正本パスは packages/contracts/openapi/internal-reco-api.yaml。本Taskは方針記載のみとし、ファイル変更は out_of_scope。"
+  - "親 Epic Issue #391 / Branch feature/epic-391-int-001-reco-health-check に整合。Task PR は親 Epic Branch を target とする。"
+  - "親 Epic epic_scope: allowed_paths は docs/06_実装設計/api/API-INT-001_* 等。本Taskは契約仕様書のみ作成し、apps/reco/src/reco/application/** 等 forbidden_paths への変更を含めない。"
+  - "出力先は docs/06_実装設計/api/（プロジェクトディレクトリ構成定義書 §10.5）。命名: task.title API-INT-001:RecoヘルスチェックAPI契約仕様書作成、成果物 API-INT-001_RecoヘルスチェックAPI契約仕様書.md、Branch english-summary に api-int-001 と api-contract-spec を含める。"


### PR DESCRIPTION
## Summary

- API-INT-001（Recoヘルスチェック / Internal API、`GET /internal/reco/v1/health`）の契約面仕様書を新規作成
- Task Definition（`api-contract-spec.yaml`）および Review Definition（`pr-review.yaml`）を追加
- Provider: `apps/reco` エンドポイント層、Consumer: `apps/api`（MOD-API-005 Reco Client）

## 変更ファイル

| ファイル | 操作 |
| -------- | ---- |
| `docs/06_実装設計/api/API-INT-001_RecoヘルスチェックAPI契約仕様書.md` | 新規 |
| `prompts/definitions/tasks/api-int-001-reco-health-check/api-contract-spec.yaml` | 新規 |
| `prompts/definitions/reviews/api-int-001-reco-health-check/pr-review.yaml` | 新規 |

## Task Definition

`prompts/definitions/tasks/api-int-001-reco-health-check/api-contract-spec.yaml`

## 関連Issue

Related to #392
Related to #391

## 検証結果

| 検証 | 結果 |
| ---- | ---- |
| API一覧 API-INT-001 との整合確認（endpoint / GET / Internal / MVP） | 実施済み |
| API設計方針書 §8.2 data+meta / §11.3 Internal 保護との整合 | 実施済み |
| secret / .env 実値の非含有確認 | 実施済み |
| markdownlint | 未実施（CI または後続 AI Review で確認） |
| unit / integration / contract test | 対象外（契約 docs のみ） |

## 未実施事項

- `markdownlint` のローカル実行
- OpenAPI / Orval / generated 変更（後続 Contract Task で実施）

## 影響範囲

- docs: API-INT-001 契約仕様書（新規）
- prompts: Task / Review Definition（新規）
- code / OpenAPI / generated / DB: 変更なし

## Human Review観点

- `GET /internal/reco/v1/health` の Endpoint と api→reco I/F 境界
- Internal API Key をヘルスチェックでも必須とする方針
- Response `data.status` の値域（`ok` / `degraded` / `unavailable`）と MVP 必須範囲
- `data.version` を optional とした方針
- OpenAPI Contract Task（`internal-reco-api.yaml`）への分離方針


Made with [Cursor](https://cursor.com)