### PR TITLE
docs: API-PUB-001 APIヘルスチェックAPI契約仕様書（1a）

### DIFF
--- a/docs/06_実装設計/api/API-PUB-001_APIヘルスチェックAPI契約仕様書.md
+++ b/docs/06_実装設計/api/API-PUB-001_APIヘルスチェックAPI契約仕様書.md
@@ -1,0 +1,347 @@
+# APIヘルスチェック API契約仕様書
+
+> 本書は **API-PUB-001** の契約面（Public I/F）正本である。
+> 処理フロー・MOD-API 責務・依存コンポーネント（DB / reco）チェック詳細・結合テスト観点は `API-PUB-001_APIヘルスチェックAPI実装仕様書.md`（別 Task）で定義する。
+> OpenAPI 正本は `packages/contracts/openapi/public-api.yaml`（別 Contract Task）。
+
+## 1. ドキュメント情報
+
+| 項目           | 内容                                      |
+| -------------- | ----------------------------------------- |
+| ドキュメントID | `API-PUB-001-CONTRACT`                    |
+| ドキュメント名 | APIヘルスチェック API契約仕様書           |
+| 対象システム   | Gift Recommendation Service MVP（Public） |
+| MVP対象        | `○`                                       |
+| 作成日         | 2026-06-05                                |
+| 更新日         | 2026-06-05                                |
+
+---
+
+## 2. 概要
+
+web（`apps/web`）および運用確認（監視・疎通確認）から api（`apps/api`）へ、API レイヤの稼働状態を確認する Public API である。関連リソースは **Health** であり、Response では **API稼働状態** を返す（[API一覧](../../05_アプリケーション設計/アプリ/api/API一覧.md) §API-PUB-001）。
+
+---
+
+## 3. 目的
+
+- 監視・疎通確認・運用確認が利用する Request / Response / Error を確定する。
+- 後続の OpenAPI Contract Task（`public-api.yaml`）および Contract Gate の入力とする。
+- API設計方針書・API一覧・エラーコード定義書と整合した契約面を提供する。
+
+---
+
+## 4. API基本情報
+
+| 項目     | 内容                                              |
+| -------- | ------------------------------------------------- |
+| API ID   | `API-PUB-001`                                     |
+| API名    | APIヘルスチェック                                 |
+| API種別  | `Public API`                                      |
+| Method   | `GET`                                             |
+| Endpoint | `/api/v1/health`                                  |
+| Base URL | 環境ごとに環境変数で定義（本書ではパスを正とする） |
+| Version  | `v1`（URL パスに含む）                            |
+| Provider | `apps/api`                                        |
+| Consumer | `apps/web` / 運用確認（監視・疎通確認）           |
+| 認証要否 | `false`（MVP は非認証。後続で Authorization 追加可） |
+| 権限条件 | MVP ではなし                                      |
+| 冪等性   | `冪等`（同一 Request の繰り返しで副作用なし）     |
+| MVP対象  | `○`                                               |
+
+---
+
+## 5. 利用シーン
+
+### 5.1 利用タイミング
+
+- デプロイ後・定期監視による API 稼働確認時
+- web 起動時または画面表示前の疎通確認時（任意）
+- 運用ツール・ロードバランサ・監視システムからのヘルスプローブ時
+
+### 5.2 呼び出し元
+
+- `apps/web`（任意の疎通確認）
+- 運用確認（監視・疎通確認）
+
+### 5.3 主なユースケース
+
+- API プロセスが応答可能であることを確認する。
+- HTTP 200 かつ `data.status: "ok"` を正常系として扱う。
+- 障害時は HTTP 5xx と `GRS-COM-*` エラーコードで調査可能にする。
+
+---
+
+## 6. Request仕様
+
+### 6.1 Request Header
+
+| Header       | 必須    | 内容               | 例                                   |
+| ------------ | ------- | ------------------ | ------------------------------------ |
+| `Accept`     | `false` | `application/json` | `application/json`                   |
+| `X-Trace-Id` | `false` | 横断追跡 ID        | `550e8400-e29b-41d4-a716-446655440000` |
+| `X-Request-Id` | `false` | API リクエスト ID  | `req_01HZYX`                         |
+
+MVP では `Authorization` は使用しない。`Content-Type` は Request Body がないため不要。
+
+### 6.2 Path Parameters
+
+| 項目 | 型 | 必須 | 内容 | 例 |
+| ---- | -- | ---- | ---- | -- |
+| -    | -  | -    | なし | -  |
+
+### 6.3 Query Parameters
+
+| 項目 | 型 | 必須 | 内容 | 制約 | 例 |
+| ---- | -- | ---- | ---- | ---- | -- |
+| -    | -  | -    | なし | -    | -  |
+
+### 6.4 Request Body
+
+なし（GET では Request Body を使用しない。API設計方針書 §6）。
+
+### 6.5 Request Example
+
+Request Body なし。例:
+
+```http
+GET /api/v1/health HTTP/1.1
+Host: api.example.com
+Accept: application/json
+```
+
+---
+
+## 7. Response仕様
+
+### 7.1 Response Header
+
+| Header         | 内容               | 例                |
+| -------------- | ------------------ | ----------------- |
+| `Content-Type` | `application/json` | `application/json` |
+
+### 7.2 Status Code
+
+| Status | 意味 | 利用条件 |
+| -----: | ---- | -------- |
+| 200 | 処理成功（API 稼働中） | api プロセスが応答可能で Health 情報を返却できる場合 |
+| 500 | 内部エラー | 想定外の処理失敗（`GRS-COM-999`） |
+| 503 | 一時利用不可 | api が一時的に応答不能（`GRS-COM-003`） |
+| 504 | タイムアウト | 内部処理タイムアウト（`GRS-COM-002`） |
+
+**契約上の正常系:** HTTP **200** かつ `data.status: "ok"`。監視・疎通確認用途のため、軽量応答を基本とする（API一覧 §API-PUB-001 備考）。
+
+### 7.3 Response Body
+
+成功時は API設計方針書 §8.2 の **`data` + `meta`** 構造を基本とする。主データは **Health** リソースの表面表現（API稼働状態）とする。
+
+#### 7.3.1 `data`（Health）
+
+| 項目 | 型 | 必須 | 内容 | 備考 |
+| ---- | -- | ---- | ---- | ---- |
+| `status` | `string` | `true` | API 稼働状態 | enum: `ok` / `degraded` / `unavailable`（OpenAPI Task で固定） |
+| `service` | `string` | `true` | サービス識別子 | 例: `gift-recommendation-api` |
+| `apiVersion` | `string` | `true` | API バージョン | URL パス `v1` と整合。例: `v1` |
+| `checkedAt` | `string` | `false` | ヘルス判定日時（ISO 8601） | 未指定時は `meta.generatedAt` を参照可 |
+
+**契約面の `status` 意味（MVP）:**
+
+| 値 | 意味 | HTTP Status（原則） |
+| -- | ---- | ------------------- |
+| `ok` | api プロセスが正常応答可能 | 200 |
+| `degraded` | api は応答するが一部依存に劣化あり | 200（契約上は応答可。監視閾値は実装仕様書で定義） |
+| `unavailable` | api が正常な Health を返せない | 503 |
+
+依存コンポーネント（DB / reco）の個別チェック結果・閾値・タイムアウトは本契約では **表面化しない**。実装仕様書 Task で定義する（§14.1 No.1）。
+
+#### 7.3.2 `meta`
+
+| 項目 | 型 | 必須 | 内容 | 備考 |
+| ---- | -- | ---- | ---- | ---- |
+| `traceId` | `string` | `false` | 横断追跡 ID | API一覧では trace_id 対象は任意。指定時は Header を引き継ぎまたは生成 |
+| `requestId` | `string` | `false` | API リクエスト ID | 未指定時は api 側で生成可 |
+| `generatedAt` | `string` | `false` | 生成日時（ISO 8601） | - |
+
+### 7.4 Response Example
+
+#### 7.4.1 正常系（200）
+
+```json
+{
+  "data": {
+    "status": "ok",
+    "service": "gift-recommendation-api",
+    "apiVersion": "v1",
+    "checkedAt": "2026-06-05T09:00:00+09:00"
+  },
+  "meta": {
+    "traceId": "550e8400-e29b-41d4-a716-446655440000",
+    "requestId": "req_01HZYX",
+    "generatedAt": "2026-06-05T09:00:00+09:00"
+  }
+}
+```
+
+#### 7.4.2 劣化あり（200・契約上は応答可）
+
+```json
+{
+  "data": {
+    "status": "degraded",
+    "service": "gift-recommendation-api",
+    "apiVersion": "v1"
+  },
+  "meta": {
+    "generatedAt": "2026-06-05T09:01:00+09:00"
+  }
+}
+```
+
+---
+
+## 8. Error Response仕様
+
+### 8.1 Error Response形式
+
+エラー時は API設計方針書 §8.3 に準拠する。`meta.traceId` / `meta.requestId` は可能な範囲で返す。
+
+```json
+{
+  "error": {
+    "code": "GRS-COM-003",
+    "message": "現在サービスを利用できません。時間を置いて再度お試しください。",
+    "details": []
+  },
+  "meta": {
+    "traceId": "550e8400-e29b-41d4-a716-446655440001",
+    "requestId": "req_01HZYY"
+  }
+}
+```
+
+### 8.2 Error一覧（本 API で想定する代表）
+
+| Status | Error Code | 発生条件 | Response概要 | ユーザー向け表示 |
+| -----: | ---------- | -------- | ------------ | ---------------- |
+| 500 | `GRS-COM-999` | 想定外内部エラー | 内部エラー | 予期しないエラーが発生しました。時間を置いて再度お試しください。 |
+| 503 | `GRS-COM-003` | 一時的利用不可 | サービス一時停止 | 現在サービスを利用できません。時間を置いて再度お試しください。 |
+| 504 | `GRS-COM-002` | タイムアウト | タイムアウト | 処理に時間がかかっています。時間を置いて再度お試しください。 |
+
+本 API では Request Body を持たないため、`GRS-COM-001`（Bad Request）等の Validation 系は原則発生しない。不正な HTTP メソッド（例: POST）は api ルーティング層で 405 等として扱う（本契約の Error 一覧外。実装仕様書で整理）。
+
+API一覧の主なエラーコード `GRS-COM-*` に整合する。`GRS-REC-*` / `GRS-DB-*` 等は本 Public Health API の契約 Error 一覧には含めない（内部障害は `GRS-COM-003` / `GRS-COM-999` へ集約可）。
+
+---
+
+## 9. バリデーション仕様
+
+| 対象項目 | ルール | エラーコード | エラーメッセージ |
+| -------- | ------ | ------------ | ---------------- |
+| HTTP Method | `GET` のみ許可 | - | ルーティング層で拒否（405 等は実装仕様書で定義） |
+| Request Body | 送信しない | - | GET では Body なし |
+| Path / Query | 本 API ではパラメータなし | - | 未知 Query は無視または 400（実装仕様書で統一） |
+
+構文 Validation の対象は最小限とする（軽量ヘルスチェックのため）。
+
+---
+
+## 10. OpenAPI / generated 反映方針
+
+| 項目 | 内容 |
+| ---- | ---- |
+| OpenAPI正本 | `packages/contracts/openapi/public-api.yaml` |
+| 操作 ID（案） | `getHealth` または `healthCheck`（OpenAPI Task で確定） |
+| Path | `/api/v1/health` |
+| components schema | `HealthResponse` / `HealthStatus` 等（OpenAPI Task で命名確定） |
+| Orval設定 | リポジトリ正本 `orval.config.ts` |
+| generated出力先（web） | `apps/web/src/generated/api/` |
+| OpenAPI定義書 | `openapi-spec.md` テンプレ準拠の Contract Task 成果物 |
+
+本 Task では YAML / generated の**実変更は行わない**。本契約仕様書を 1b OpenAPI Contract Task の入力正本とする。
+
+Contract Gate 通過後に Implementation Task（`api-implementation-spec`）および apps 実装 Task を開始する。
+
+---
+
+## 11. 互換性・破壊的変更
+
+| 項目       | 内容 |
+| ---------- | ---- |
+| 破壊的変更 | MVP 初版のためなし |
+| 後方互換性 | `v1` パス固定。フィールド追加は optional で許容 |
+| 判断理由   | 初回 Public Health 契約確定 |
+
+### 11.1 rollout order
+
+- 本契約確定 → `public-api.yaml` 更新 → Orval 再生成 → web api-client 更新（任意）→ api 実装
+
+---
+
+## 12. 契約面テスト観点
+
+| No | 観点 | 確認内容 | 種別 |
+| --: | ---- | -------- | ---- |
+| 1 | 正常系 | GET で 200、`data.status: "ok"` | contract |
+| 2 | 冪等性 | 同一 Endpoint の連続 GET で副作用なし | contract |
+| 3 | Response 構造 | `data` + `meta`、必須フィールド存在 | contract |
+| 4 | エラー系 | 503 + `GRS-COM-003` の形式 | contract |
+| 5 | trace 伝播 | `X-Trace-Id` 指定時に `meta.traceId` が一致（任意） | contract |
+| 6 | generated client | OpenAPI 生成後、型が Response と一致 | typecheck |
+
+実装結合・依存コンポーネント障害シミュレーションは実装仕様書・単体テスト Task で扱う。
+
+---
+
+## 13. 変更履歴
+
+| 日付 | 変更内容 | 関連Issue / PR |
+| ---- | -------- | -------------- |
+| 2026-06-05 | 初版（契約面のみ。Phase1 Wave2 C2 batch1） | Epic #384 |
+
+---
+
+## 14. 未決事項
+
+| No | 論点 | 判断が必要な理由 | 判断者 | 期限 | 備考 |
+| --: | ---- | ---------------- | ------ | ---- | ---- |
+| 1 | 依存コンポーネント（DB / reco）チェックを Response に含めるか | `degraded` 判定の契約面定義に影響 | Human | - | 実装仕様書 Task と合わせて確定推奨 |
+| 2 | `degraded` 時の HTTP Status を 200 固定とするか | 監視アラート閾値に影響 | Human | - | 本書は契約上 200 を原則とした |
+| 3 | `service` 識別子の正式文字列 | OpenAPI example / 監視ダッシュボード整合 | Human | - | 例は `gift-recommendation-api` |
+
+---
+
+## 15. 関連資料
+
+| 種別 | パス / URL | 用途 |
+| ---- | ---------- | ---- |
+| API一覧 | `docs/05_アプリケーション設計/アプリ/api/API一覧.md` | API-PUB-001 行 |
+| API設計方針書 | `docs/05_アプリケーション設計/アプリ/api/API設計方針書.md` | Request/Response/Error 形式 |
+| エラーコード定義書 | `docs/05_アプリケーション設計/アプリ/エラーコード定義書.md` | GRS-COM-* |
+| ログ・Observability設計書 | `docs/05_アプリケーション設計/アプリ/ログ・Observability設計書.md` | access_log / metric |
+| 可用性要件 | `docs/03_ドメイン要件定義/非機能要件定義書/可用性要件.md` | ヘルスチェック要件 |
+| Task Definition | `prompts/definitions/tasks/api-pub-001-api-health-check/api-contract-spec.yaml` | Epic #384 配下 scope |
+| Epic Definition | `prompts/definitions/epics/api-pub-001-api-health-check/epic.yaml` | epic_scope |
+
+---
+
+## 16. レビュー観点
+
+- API契約（Request / Response / Error / Validation）が明確で、OpenAPI Task の入力として十分か
+- API設計方針書 §8（data/meta 構造）と矛盾していないか
+- API一覧の API-PUB-001（endpoint / Method / Health リソース / GRS-COM-*）と一致しているか
+- 実装面（MOD-API フロー・依存チェック詳細）を含んでいないか
+- secret / `.env` 実値が含まれていないか
+
+### 16.1 Human Review で確認してほしいこと
+
+- 正式 Endpoint（`GET /api/v1/health`）と MVP 非認証方針の最終確認
+- §14 の `status` enum と依存コンポーネント表面化範囲
+- OpenAPI Contract Task への分離方針の確認
+
+---
+
+## 17. 備考
+
+- 本書は `prompts/templates/docs/api-contract-spec.md` に準拠した Phase1 ①（1a）成果物である。
+- API-INT-001（Recoヘルスチェック）は別 API。本書では web↔api の Public Health 境界のみを正とする。
+- ログ・Observability（access_log / api_request_count / api_error_count）は API一覧に準拠。実装記録方針は実装仕様書で扱う。

--- a/prompts/definitions/reviews/api-pub-001-api-health-check/pr-review.yaml
+++ b/prompts/definitions/reviews/api-pub-001-api-health-check/pr-review.yaml
@@ -1,0 +1,164 @@
+schema_version: "1.0"
+definition_type: "review"
+
+review:
+  id: "review-api-pub-001-api-health-check-pr"
+  title: "API-PUB-001 APIヘルスチェックAPI契約仕様書 PRレビュー"
+  summary: "API-PUB-001（APIヘルスチェック / Public API）API契約仕様書作成 Task（api-contract-spec.yaml）の PR を AI Review する"
+  type: "task_pr_review"
+  status: "ready"
+
+work_mode: "ai-agent"
+
+branch:
+  no_branch: true
+  name: null
+  base: null
+  target: null
+  worktree_required: false
+
+target:
+  pr: null
+  issue: null
+  task_definition: "prompts/definitions/tasks/api-pub-001-api-health-check/api-contract-spec.yaml"
+  source_branch: "docs/task-<issue-number>-api-pub-001-api-health-check-api-contract-spec"
+  target_branch: "feature/epic-384-pub-001-api-health-check"
+  parent_epic_issue: "[Epic]API-PUB-001:APIヘルスチェック"
+  parent_epic_branch: "feature/epic-384-pub-001-api-health-check"
+
+commands:
+  primary: "/review-pr"
+  allowed:
+    - "/review-pr"
+    - "/summarize-work"
+  next:
+    approve_for_human_review: "Human Review"
+    request_changes: "/fix-review-comments"
+    needs_human_decision: "Human Decision"
+    split_required: "/start-task"
+    blocked: null
+
+agent:
+  primary: "reviewer-ai"
+  support:
+    - "support-ai"
+  specialist:
+    docs: "docs-reviewer-ai"
+    test: null
+    contract: "contract-ai"
+    security: null
+  next:
+    fixer: "fixer-ai"
+    human: "human-reviewer"
+
+review_scope:
+  docs: true
+  source: false
+  tests: false
+  api_contract: true
+  db: false
+  generated: true
+  cicd: false
+  security: true
+  project_operation: true
+
+input:
+  task_definition:
+    path: "prompts/definitions/tasks/api-pub-001-api-health-check/api-contract-spec.yaml"
+    required: true
+  issue:
+    number: null
+    required: true
+  pr:
+    number: null
+    required: true
+  diff:
+    required: true
+    compare_with: "feature/epic-384-pub-001-api-health-check"
+  docs:
+    - path: "docs/06_実装設計/api/API-PUB-001_APIヘルスチェックAPI契約仕様書.md"
+      required: true
+      purpose: "作成成果物（契約面）の内容確認"
+    - path: "docs/05_アプリケーション設計/アプリ/api/API一覧.md"
+      required: true
+      purpose: "API-PUB-001 行との整合確認"
+    - path: "docs/05_アプリケーション設計/アプリ/api/API設計方針書.md"
+      required: true
+      purpose: "URL / Method / 認証 / Error 形式との整合確認"
+    - path: "docs/05_アプリケーション設計/アプリ/エラーコード定義書.md"
+      required: true
+      purpose: "GRS-COM-* との整合確認"
+  files: []
+  test_results:
+    required: true
+    source: "pr_body"
+  ci_results:
+    required: false
+    source: "not_required"
+  templates:
+    review_outputs:
+      pr_comment: "prompts/templates/review/ai-review-comment.md"
+      slack: "prompts/templates/slack/ai-review-result.md"
+    deliverables:
+      - path: "prompts/templates/docs/api-contract-spec.md"
+        required: true
+        purpose: "Task成果物が api-contract-spec.md に沿って作成されているか確認するため"
+        applies_to:
+          - "docs/06_実装設計/api/API-PUB-001_APIヘルスチェックAPI契約仕様書.md"
+
+review_points:
+  common:
+    - "Task Definition（api-contract-spec.yaml）の scope を満たしているか"
+    - "out_of_scope（OpenAPI / 実装 / 他API）の変更が混在していないか"
+    - "acceptance_criteria を満たしているか"
+    - "Task Branch から develop へ直接 PR していないか（target は親 Epic Branch）"
+  docs:
+    - "api-contract-spec.md テンプレート準拠か"
+    - "実装面が混入していないか"
+    - "API一覧の API-PUB-001 と整合しているか"
+  api_contract:
+    - "OpenAPI / generated 変更が混在していないか"
+  security:
+    - "secret や .env 実値が含まれていないか"
+  epic_scope:
+    - "PR差分が親 Epic #384 の epic_scope.allowed_paths 内に収まっているか"
+
+acceptance_check:
+  use_task_acceptance_criteria: true
+
+result_policy:
+  approve_for_human_review:
+    conditions:
+      - "acceptance_criteria を満たしている"
+      - "scope 外変更がない"
+  request_changes:
+    conditions:
+      - "docs 不備がある"
+      - "テンプレート準拠が欠落している"
+
+status_policy:
+  current_status: "AI Review"
+  on_approve: "Human Review"
+  on_request_changes: "In Progress"
+
+outputs:
+  pr_comment_template: "prompts/templates/review/ai-review-comment.md"
+  slack_template: "prompts/templates/slack/ai-review-result.md"
+  update_pr_body: false
+  create_follow_up_issue: false
+
+project:
+  project_name: "Gift Recommendation Service MVP Cycle 3"
+  fields:
+    phase: "06_実装設計"
+    status: "AI Review"
+
+issue:
+  unit: "task"
+  type: "docs"
+  area: "api"
+
+notes:
+  - "review.target / input.issue.number / input.pr.number は実 PR / Issue 起票後に追記する"
+  - "対応 Task Definition: prompts/definitions/tasks/api-pub-001-api-health-check/api-contract-spec.yaml"
+  - "対応 Epic Definition: prompts/definitions/epics/api-pub-001-api-health-check/epic.yaml"

--- a/prompts/definitions/reviews/api-pub-001-api-health-check/pr-review.yaml
+++ b/prompts/definitions/reviews/api-pub-001-api-health-check/pr-review.yaml
@@ -18,10 +18,10 @@ branch:
   worktree_required: false
 
 target:
-  pr: null
-  issue: null
+  pr: 394
+  issue: 395
   task_definition: "prompts/definitions/tasks/api-pub-001-api-health-check/api-contract-spec.yaml"
-  source_branch: "docs/task-<issue-number>-api-pub-001-api-health-check-api-contract-spec"
+  source_branch: "docs/task-api-pub-001-api-health-check-api-contract-spec"
   target_branch: "feature/epic-384-pub-001-api-health-check"
   parent_epic_issue: "[Epic]API-PUB-001:APIヘルスチェック"
   parent_epic_branch: "feature/epic-384-pub-001-api-health-check"
@@ -67,10 +67,10 @@ input:
     path: "prompts/definitions/tasks/api-pub-001-api-health-check/api-contract-spec.yaml"
     required: true
   issue:
-    number: null
+    number: 395
     required: true
   pr:
-    number: null
+    number: 394
     required: true
   diff:
     required: true
@@ -159,6 +159,6 @@ issue:
   area: "api"
 
 notes:
-  - "review.target / input.issue.number / input.pr.number は実 PR / Issue 起票後に追記する"
+  - "Task Issue #395 / PR #394 に追記済み（branch 名は起票前作成のため issue 番号非含有）"
   - "対応 Task Definition: prompts/definitions/tasks/api-pub-001-api-health-check/api-contract-spec.yaml"
   - "対応 Epic Definition: prompts/definitions/epics/api-pub-001-api-health-check/epic.yaml"

--- a/prompts/definitions/tasks/api-pub-001-api-health-check/api-contract-spec.yaml
+++ b/prompts/definitions/tasks/api-pub-001-api-health-check/api-contract-spec.yaml
@@ -1,0 +1,285 @@
+schema_version: "1.0"
+definition_type: "task"
+
+task:
+  id: "task-api-pub-001-api-health-check-api-contract-spec"
+  title: "API-PUB-001:APIヘルスチェックAPI契約仕様書作成"
+  summary: "API-PUB-001（APIヘルスチェック / Public API、GET /api/v1/health）の API 契約仕様書（API-PUB-001_APIヘルスチェックAPI契約仕様書.md）を、api-contract-spec.md 準拠で作成する。実装面は別 Task（api-implementation-spec.yaml）へ分離する。"
+
+work_mode: "ai-agent"
+
+parent:
+  epic_issue: "[Epic]API-PUB-001:APIヘルスチェック"
+  epic_issue_number: 384
+  epic_branch: "feature/epic-384-pub-001-api-health-check"
+  related_issues: []
+  related_prs: []
+
+commands:
+  primary: "/start-task"
+  allowed:
+    - "/start-task"
+    - "/work-issue"
+    - "/create-pr"
+    - "/fix-review-comments"
+    - "/summarize-work"
+  next:
+    success: "/work-issue"
+    review_fix: "/fix-review-comments"
+    blocked: null
+
+agent:
+  primary: "worker-ai"
+  support:
+    - "orchestrator-ai"
+    - "support-ai"
+    - "contract-ai"
+  review:
+    - "reviewer-ai"
+    - "docs-reviewer-ai"
+    - "contract-ai"
+
+background: |
+  Phase1 ① API契約仕様書（1a）として、API-PUB-001（APIヘルスチェック / Public API）の契約面（Request / Response / Error / Validation / 互換性 / OpenAPI 反映方針）を確定する。
+  実装フェーズ実行プロセス設計書 §4.1（分離後モデル）に従い、処理フロー・MOD-API 連携・依存コンポーネント詳細チェック・結合テスト観点などの実装面は本 Task の対象外とし、`api-implementation-spec.yaml` で Phase4 実装設計時に作成する。
+  API-INT-001（Recoヘルスチェック）は別 Epic/Task の対象。本 Task では Public I/F の契約確定に必要な範囲で Health リソースの表面定義のみ行う。
+
+objective: |
+  API-PUB-001（APIヘルスチェック / Public API、`GET /api/v1/health`）について、Contract Gate および後続 OpenAPI Contract Task の入力となる API 契約仕様書を作成する。
+  成果物は prompts/templates/docs/api-contract-spec.md に準拠し、契約面のみを記載する（api-implementation-spec.md の章は含めない）。
+  OpenAPI / Orval / generated の実ファイル変更は後続 Contract Task へ分離する。
+
+scope:
+  - "API-PUB-001 の API 契約仕様書を新規作成する（成果物: API-PUB-001_APIヘルスチェックAPI契約仕様書.md）"
+  - "API基本情報（API ID / API種別 Public / Method GET / Endpoint /api/v1/health / Base URL / Version / Provider apps/api / Consumer apps/web・運用確認 / 認証要否 / 冪等性 / MVP対象）を定義する"
+  - "Request Header / Path Parameters / Query Parameters / Request Body（なし）を整理する"
+  - "Response Header / Status Code / Response Body（Health リソース・API稼働状態）を整理する"
+  - "Error Response仕様（GRS-COM-*）を整理する"
+  - "バリデーション仕様を整理する"
+  - "OpenAPI / Orval / generated 反映方針（packages/contracts/openapi/public-api.yaml、apps/web/src/generated/api/ 再生成）を整理する（方針のみ。ファイル変更は out_of_scope）"
+  - "互換性・破壊的変更・契約面テスト観点を整理する"
+  - "未決事項・人間判断が必要な事項を明記する"
+
+out_of_scope:
+  - "API実装仕様書（api-implementation-spec.md 準拠）の作成（prompts/definitions/tasks/api-pub-001-api-health-check/api-implementation-spec.yaml）"
+  - "処理概要（MOD-API-001 の詳細フロー）・依存コンポーネント（DB / reco）チェック詳細・provider/consumer 実装影響の詳細・結合テスト観点の確定"
+  - "API-INT-001（Recoヘルスチェック / Internal API）の個別API仕様書作成"
+  - "Reco モジュール（MOD-RECO-*）本体の設計・実装"
+  - "OpenAPI定義ファイル（packages/contracts/openapi/public-api.yaml 等）の作成・更新"
+  - "Orval設定ファイル（orval.config.ts）の作成・更新"
+  - "generated API client（apps/web/src/generated/api/）の再生成"
+  - "apps/api の実装"
+  - "apps/web の実装"
+  - "apps/reco の実装"
+  - "DB schema 変更"
+  - "DDL 作成・変更"
+  - "認証・認可方式そのものの変更"
+  - "API一覧全体の再設計"
+  - "他 API（API-PUB-002〜008 / API-INT-001 / 002）の仕様書作成"
+
+input:
+  docs:
+    - path: "docs/05_アプリケーション設計/アプリ/api/API設計方針書.md"
+      required: true
+      purpose: "URL 設計、HTTP Method、認証、エラー形式、バージョニング、Response 構造（data/meta）等の API 設計方針を確認するため"
+    - path: "docs/05_アプリケーション設計/アプリ/api/API一覧.md"
+      required: true
+      purpose: "API-PUB-001 の endpoint、API種別、Provider、Consumer、MVP対象、関連エラーコード、Health リソースを確認するため"
+    - path: "docs/05_アプリケーション設計/アプリ/エラーコード定義書.md"
+      required: true
+      purpose: "Error Response、HTTP Status、GRS-COM-* エラーコード参照、ユーザー向け表示方針を確認するため"
+    - path: "docs/05_アプリケーション設計/基盤/認証・認可方針書.md"
+      required: false
+      purpose: "Public API の認証要否・権限条件を確認するため"
+    - path: "docs/05_アプリケーション設計/アプリ/ログ・Observability設計書.md"
+      required: false
+      purpose: "trace_id / access_log / metric 方針を確認するため"
+    - path: "docs/03_ドメイン要件定義/非機能要件定義書/可用性要件.md"
+      required: false
+      purpose: "ヘルスチェック・監視要件を確認するため"
+    - path: "docs/00_共通/プロジェクト管理/実装フェーズ実行プロセス設計書.md"
+      required: true
+      purpose: "Phase1 1a（契約面のみ）と Phase4 実装仕様書分離の正本を確認するため"
+  templates:
+    - path: "prompts/templates/docs/api-contract-spec.md"
+      required: true
+      purpose: "API 契約仕様書の標準フォーマット"
+      applies_to:
+        - "docs/06_実装設計/api/API-PUB-001_APIヘルスチェックAPI契約仕様書.md"
+  files: []
+  issues: []
+  prs: []
+
+output:
+  docs:
+    - path: "docs/06_実装設計/api/API-PUB-001_APIヘルスチェックAPI契約仕様書.md"
+      action: "create"
+      required: true
+      template: "prompts/templates/docs/api-contract-spec.md"
+  files: []
+  tests: []
+  generated:
+    expected: false
+    paths: []
+    handling: "none"
+  logs:
+    ai_logs_required: false
+    path: null
+
+deliverables:
+  - "API-PUB-001（APIヘルスチェック）API 契約仕様書（API-PUB-001_APIヘルスチェックAPI契約仕様書.md）"
+  - "Request / Response / Error Response / Validation 定義"
+  - "OpenAPI / Orval / generated 反映方針（方針整理のみ）"
+  - "互換性・契約面テスト観点"
+  - "未決事項・人間判断事項の整理"
+
+acceptance_criteria:
+  - "docs/06_実装設計/api/API-PUB-001_APIヘルスチェックAPI契約仕様書.md が作成されている"
+  - "prompts/templates/docs/api-contract-spec.md に準拠している（実装面章・内部処理詳細を含まない）"
+  - "API設計方針書と矛盾する URL / HTTP Method / 認証 / Error 形式を定義していない"
+  - "API一覧の API-PUB-001 と矛盾する endpoint / HTTP Method / API種別 / MVP対象 / Provider / Consumer / Health リソース を定義していない"
+  - "Error Response とエラーコードがエラーコード定義書（GRS-COM-*）と整合している"
+  - "OpenAPI / Orval / generated の扱いと Contract Task 分離方針が記載されている"
+  - "本Task内で OpenAPI / Orval / generated / 実装ファイルを変更していない"
+  - "api-implementation-spec.md 相当の処理フロー・MOD-API 詳細・結合テスト観点を本成果物に含めていない"
+  - "Task タイトル・成果物ファイル名が分離後モデル（契約/実装の別成果物）と整合している"
+  - "未決事項がある場合、未決事項として明記されている"
+  - "secret、APIキー、.env 実値、接続文字列の実値を含んでいない"
+  - "Human Review で確認してほしい事項が明記されている"
+
+branch:
+  no_branch: false
+  name: "docs/task-<issue-number>-api-pub-001-api-health-check-api-contract-spec"
+  base: "feature/epic-384-pub-001-api-health-check"
+  target: "feature/epic-384-pub-001-api-health-check"
+  worktree_required: false
+
+project:
+  project_name: "Gift Recommendation Service MVP Cycle 3"
+  fields:
+    phase: "06_実装設計"
+    status: "Todo"
+    priority: "medium"
+    planned_start: null
+    due_date: null
+
+issue:
+  unit: "task"
+  type: "docs"
+  area: "api"
+
+dependencies:
+  epics: []
+  issues: []
+  prs: []
+  tasks:
+    - "API設計方針書が作成済みであること"
+    - "API一覧が作成済みであること"
+    - "エラーコード定義書が作成済みであること"
+  blocking: false
+
+parallel_control:
+  depends_on: []
+  blocks:
+    - "prompts/definitions/tasks/api-pub-001-api-health-check/api-implementation-spec.yaml"
+  exclusive_files:
+    - "docs/06_実装設計/api/API-PUB-001_APIヘルスチェックAPI契約仕様書.md"
+  conflict_risk: "low"
+  generated_impact: false
+  contract_impact: true
+  db_impact: false
+
+test_policy:
+  required:
+    - "docs review"
+    - "markdown format check"
+    - "template conformity check"
+    - "api design consistency check"
+    - "api list consistency check"
+    - "request response consistency check"
+    - "error response consistency check"
+    - "contract impact check"
+    - "secret check"
+  commands:
+    - "markdownlint docs/06_実装設計/api/API-PUB-001_APIヘルスチェックAPI契約仕様書.md"
+  manual_checks:
+    - "api-contract-spec.md の章構成に準拠していることを確認する"
+    - "実装面（処理フロー・MOD-API 詳細・依存チェック詳細）が混入していないことを確認する"
+    - "API設計方針書と矛盾がないことを確認する"
+    - "API一覧の API-PUB-001 と整合していることを確認する"
+    - "OpenAPI / Orval / generated の変更を本Taskに含めていないことを確認する"
+    - "secret、.env 実値が含まれていないことを確認する"
+  not_required:
+    - "unit test"
+    - "integration test"
+    - "e2e test"
+    - "contract test"
+    - "typecheck"
+    - "build"
+  skip_reason:
+    "unit test": "docs作成Taskであり、source code変更を含まないため対象外"
+    "integration test": "docs作成Taskであり、実装変更を含まないため対象外"
+    "e2e test": "docs作成Taskであり、画面実装・API実装を含まないため対象外"
+    "contract test": "OpenAPI 定義 / generated 変更を含まないため対象外。contract impact check は必須"
+    "typecheck": "source code 変更を含まないため対象外"
+    "build": "source code 変更を含まないため対象外"
+
+review:
+  human_review_required: true
+  ai_review_required: true
+  review_points:
+    - "API 契約仕様書として粒度が過不足ないか（契約面のみ）"
+    - "API一覧の API-PUB-001 と内容が整合しているか"
+    - "API設計方針書と URL / Method / 認証 / Error 形式が整合しているか"
+    - "Health リソース・API稼働状態の Response が契約として確定可能か"
+    - "実装面（MOD-API フロー・依存チェック詳細）が混入していないか"
+    - "OpenAPI / Orval / generated 変更が Contract Task として分離されているか"
+    - "後続 api-implementation-spec Task との境界が明確か"
+    - "未決事項が隠れずに明記されているか"
+    - "secret や .env 実値が含まれていないか"
+  specialist_reviews:
+    docs: true
+    test: false
+    contract: true
+    security: true
+
+operation_logging:
+  level: "standard"
+  ai_logs:
+    intake: false
+    incidents: true
+    cross_cutting: true
+    experiments: false
+  reason: "通常の docs 作成作業は ai-logs に保存しない。必須 input 不足、作業停止、横断影響が判明した場合は incident または cross-cutting として記録する。"
+
+risk_points:
+  - "Health Response の status enum や依存コンポーネント表面化範囲の判断が必要になる可能性"
+  - "MVP の認証要否（非認証想定）と認証・認可方針書との差異が判明する可能性"
+  - "後続 OpenAPI Contract Task で契約仕様書との差分修正が必要になる可能性"
+
+human_decision_points:
+  - "API-PUB-001 の正式 Endpoint（`GET /api/v1/health`）と認証要否（MVP では非認証）の最終確認"
+  - "Response Body の `status` enum 値と依存コンポーネント（DB / reco）の契約面への含め方"
+  - "OpenAPI（paths/health）更新を後続 Contract Task として分離するかの確認"
+
+stop_conditions:
+  - "必須 `input.docs` が存在しない場合"
+  - "必須 `input.templates` が存在しない場合"
+  - "必須 `input.docs` 間に矛盾があり、AI Agent だけで判断できない場合"
+  - "API一覧に API-PUB-001 が存在しない場合"
+  - "正式 Endpoint / HTTP Method / API種別 が確定できない場合"
+  - "実装面仕様の作成が必要と判明した場合（api-implementation-spec Task へ分離）"
+  - "OpenAPI 変更が必要になった場合（Contract Task として分離）"
+  - "Orval 再生成が必要になった場合（Contract Task として分離）"
+  - "generated ファイルの手動編集が必要に見える場合"
+  - "DB schema 変更が必要になった場合"
+  - "認証・認可仕様変更が必要になった場合"
+  - "secret や .env 実値を扱う必要が出た場合"
+  - "scope 外の実装作業が必要になった場合"
+  - "本Task差分が親 Epic #384 の epic_scope.allowed_paths から外れた場合"
+
+notes:
+  - "本Taskは Phase1 ① API契約仕様書（1a）。実装フェーズ実行プロセス設計書 §4.1・§5 Phase1 に準拠。"
+  - "実装面は prompts/definitions/tasks/api-pub-001-api-health-check/api-implementation-spec.yaml（Phase4 実装設計）で作成予定。"
+  - "親 Epic #384 / Branch feature/epic-384-pub-001-api-health-check。OpenAPI・Orval・generated・apps 実装は Contract Task / 実装 Task へ分離。"
+  - "出力先は docs/06_実装設計/api/（プロジェクトディレクトリ構成定義書 §10.5）。"


### PR DESCRIPTION
## Summary

- API-PUB-001（`GET /api/v1/health`）の Phase1 ① API契約仕様書（1a）を新規作成
- Task Definition（`api-contract-spec.yaml`）および PR Review Definition（`pr-review.yaml`）を Epic #384 配下に追加
- 契約面のみ（Request / Response / Error / Validation / OpenAPI 反映方針）。実装面・OpenAPI 実変更は含まない

## 変更ファイル

| ファイル | 操作 |
| -------- | ---- |
| `docs/06_実装設計/api/API-PUB-001_APIヘルスチェックAPI契約仕様書.md` | 新規 |
| `prompts/definitions/tasks/api-pub-001-api-health-check/api-contract-spec.yaml` | 新規 |
| `prompts/definitions/reviews/api-pub-001-api-health-check/pr-review.yaml` | 新規 |

## Task Definition

- `prompts/definitions/tasks/api-pub-001-api-health-check/api-contract-spec.yaml`
- 親 Epic: #384 `[Epic]API-PUB-001:APIヘルスチェック`
- PR target: `feature/epic-384-pub-001-api-health-check`

## 検証結果

| 検証 | 結果 |
| ---- | ---- |
| api-contract-spec.md 章構成準拠 | 手動確認済み |
| API一覧 API-PUB-001 整合 | 手動確認済み |
| API設計方針書（data/meta、GET、非認証）整合 | 手動確認済み |
| GRS-COM-* エラーコード整合 | 手動確認済み |
| OpenAPI / generated 変更なし | 確認済み（差分なし） |
| secret / .env 実値なし | 確認済み |
| markdownlint | 未実施（CI または Reviewer AI へ委譲） |
| unit / integration / contract test | 未実施（docs のみ Task のため対象外） |

## 未実施事項

- markdownlint 実行
- Task Issue 起票（Issue 番号確定後に branch 名・pr-review.yaml の `issue` / `pr` を追記）

## 影響範囲

- docs / prompts のみ
- OpenAPI / generated / apps 実装への変更なし
- DB schema 変更なし

## Human Review 観点

- `GET /api/v1/health` と MVP 非認証方針の最終確認
- Health Response の `status` enum（`ok` / `degraded` / `unavailable`）と依存コンポーネント表面化範囲（§14 未決事項）
- OpenAPI Contract Task 分離方針の確認
- epic_scope.allowed_paths 内に収まっていること

## 関連 Issue

Related to #384

Made with [Cursor](https://cursor.com)