### PR TITLE
[Task]pair_master:Pair Masterテーブル定義書作成

### DIFF
--- a/docs/06_実装設計/database/pair_master_テーブル定義書.md
+++ b/docs/06_実装設計/database/pair_master_テーブル定義書.md
@@ -1,0 +1,247 @@
+# Pair Master テーブル定義書
+
+## 1. ドキュメント情報
+
+| 項目           | 内容                               |
+| -------------- | ---------------------------------- |
+| ドキュメントID | `DB-TBL-MVP-pair_master`           |
+| ドキュメント名 | Pair Master テーブル定義書         |
+| 対象システム   | Gift Recommendation Service MVP    |
+| MVP対象        | `yes`                              |
+| 作成日         | 2026-06-08                         |
+| 更新日         | 2026-06-08                         |
+
+---
+
+## 2. 概要
+
+`pair_master` は、贈答シーンにおける **Relationship × Occasion の有効な組み合わせ（Pair）** を管理するマスタである。
+
+Reco 実行時に `relationship_code` と `occasion_code` から `pair_id` を解決し、再現性確保のため `recommendation_run` に固定する。Public API では Pair 情報を公開しない。
+
+---
+
+## 3. 目的
+
+- Relationship × Occasion の有効組み合わせを DB 上で一意に管理する
+- Reco 実行時の Pair 解決（`relationship_code` + `occasion_code` → `pair_id`）の正本とする
+- `recommendation_run.pair_id` の物理 FK 参照先として、Run 単位の再現性を担保する
+- `pair_rule` 等の後続 Rule テーブルが参照する Pair 体系の基盤とする
+
+---
+
+## 4. テーブル基本情報
+
+| 項目 | 内容 |
+| ---- | ---- |
+| 物理テーブル名 | `pair_master` |
+| 論理テーブル名 | Pair Master |
+| 分類 | Master / Config系 |
+| 正本区分 | 設定正本 |
+| 主な更新主体 | database（seed / 運用更新） |
+| 主な参照主体 | api（Pair 解決）、reco（Feature 生成時の Pair 参照） |
+| MVP対象 | `yes` |
+| 関連物理ER | `docs/06_実装設計/database/物理ER.md` §8〜§11 |
+
+---
+
+## 5. 用途・責務
+
+- Relationship × Occasion の **有効な組み合わせ** を `pair_id`（サロゲートキー）で識別する
+- Reco 実行時、`relationship_code` と `occasion_code` から `pair_id` を解決する（`is_active = true` の行のみ対象とする想定）
+- 解決した `pair_id` を `recommendation_run` に保持し、同一 Run の再現性を担保する（物理ER §17 No.1）
+- **Public API（API-PUB-005 / API-PUB-006）では Pair 情報を返却しない**。Pair 利用は Reco 内部処理または Internal API 側で扱う
+
+### 5.1 対象外
+
+- Pair ごとの Feature 補正値（`pair_rule` の責務）
+- Relationship / Occasion 個別マスタの定義（`relationship_master` / `occasion_master` の責務）
+- Pair 一覧の Public API 公開
+- `recommendation_request` への `pair_id` 保持（Request は `relationship_code` / `occasion_code` のみ。物理ER §17 No.1）
+
+---
+
+## 6. カラム定義
+
+| No | カラム名 | 論理名 | 型 | 必須 | PK | FK | Unique | Default | 説明 |
+| --: | -------- | ------ | -- | ---- | -- | -- | ------ | ------- | ---- |
+| 1 | `pair_id` | Pair ID | `uuid` | `yes` | `yes` | — | `yes` | `gen_random_uuid()` | Pair のサロゲートキー。`recommendation_run.pair_id` の参照先 |
+| 2 | `relationship_code` | Relationship Code | `text` | `yes` | — | `yes` | — | — | `relationship_master.relationship_code` への物理 FK |
+| 3 | `occasion_code` | Occasion Code | `text` | `yes` | — | `yes` | — | — | `occasion_master.occasion_code` への物理 FK |
+| 4 | `is_active` | Active Flag | `boolean` | `yes` | — | — | — | `true` | 有効フラグ。`false` の行は Pair 解決対象外 |
+
+> **論理ER との差分**: 論理ER §11.1 には `pair_master` エンティティが未掲載である。本テーブルは物理ER §4.1 No.3 に基づき物理設計で追加する（テーブル一覧 §14 No.13）。論理ER 側の整理は別 Task とする。
+
+---
+
+## 7. 主キー・一意キー
+
+| 種別 | 対象カラム | 方針 | 備考 |
+| ---- | ---------- | ---- | ---- |
+| PRIMARY KEY | `pair_id` | サロゲートキー（uuid）を採用 | 物理ER §5 主キー方針に整合 |
+| UNIQUE | `relationship_code`, `occasion_code` | 組み合わせ一意 | 制約名 `uq_pair_relationship_occasion`（物理ER §10・§11） |
+
+---
+
+## 8. 外部キー・参照関係
+
+### 8.1 参照先（Outgoing FK）
+
+| カラム | 参照先 | FK制約 | 参照整合性 | 備考 |
+| ------ | ------ | ------ | ---------- | ---- |
+| `relationship_code` | `relationship_master.relationship_code` | `ON` | `RESTRICT`（推奨） | Master 物理 FK。Human Review #443 踏襲方針 |
+| `occasion_code` | `occasion_master.occasion_code` | `ON` | `RESTRICT`（推奨） | Master 物理 FK。Human Review #448 踏襲方針 |
+
+> `recommendation_request.relationship_code` / `occasion_code` は Master を **論理参照**（LOGICAL）とするが、本テーブルは Master への **物理 FK** を採用する。Pair 組み合わせの参照整合性を DB 制約で担保するため。
+
+### 8.2 被参照（Incoming FK）
+
+| 参照元 | 参照列 | 関係 | FK制約 | 備考 |
+| ------ | ------ | ---- | ------ | ---- |
+| `recommendation_run` | `pair_id` | resolved_at_run | `ON` | 実行時解決 Pair を Run に保持（物理ER §9・§17 No.1） |
+
+### 8.3 論理参照（後続 Task）
+
+| 参照元 | 参照列 | 関係 | FK制約 | 備考 |
+| ------ | ------ | ---- | ------ | ---- |
+| `pair_rule` | `relationship_code`, `occasion_code` | Feature 補正 | 後続 Task で確定 | Featureルール定義書 §17.3。`pair_id` 参照か codes 参照かは Rule テーブル定義 Task で確定 |
+
+---
+
+## 9. Index
+
+| Index名 | 対象カラム | 種別 | 用途 | 備考 |
+| ------- | ---------- | ---- | ---- | ---- |
+| `pair_master_pkey` | `pair_id` | btree（PK） | 主キー | 自動生成 |
+| `uq_pair_relationship_occasion` | `relationship_code`, `occasion_code` | unique | 組み合わせ一意 | 物理ER §10 |
+| `idx_pair_master_resolve` | `relationship_code`, `occasion_code`, `is_active` | btree | Pair 解決（`is_active=true` 条件付き Lookup） | Reco 実行時の解決クエリ向け |
+
+---
+
+## 10. 制約
+
+| 制約名 | 種別 | 対象 | 内容 | 備考 |
+| ------ | ---- | ---- | ---- | ---- |
+| `pair_master_pkey` | PRIMARY KEY | `pair_id` | 主キー | — |
+| `uq_pair_relationship_occasion` | UNIQUE | `relationship_code`, `occasion_code` | 組み合わせ一意 | 物理ER §11 |
+| `fk_pair_master_relationship` | FOREIGN KEY | `relationship_code` | `relationship_master.relationship_code` 参照 | ON DELETE RESTRICT（推奨） |
+| `fk_pair_master_occasion` | FOREIGN KEY | `occasion_code` | `occasion_master.occasion_code` 参照 | ON DELETE RESTRICT（推奨） |
+| `chk_relationship_code_format` | CHECK | `relationship_code` | `relationship_code ~ '^[a-z][a-z0-9_]*$'` | relationship_master と同一形式 |
+| `chk_occasion_code_format` | CHECK | `occasion_code` | `occasion_code ~ '^[a-z][a-z0-9_]*$'` | occasion_master と同一形式 |
+
+---
+
+## 11. 状態・enum
+
+| カラム | enum / code | 定義元 | 許容値 | 備考 |
+| ------ | ----------- | ------ | ------ | ---- |
+| — | — | なし | — | 状態カラムなし。`is_active` は boolean |
+
+---
+
+## 12. 更新仕様
+
+| 操作 | 実行主体 | 条件 | 更新項目 | 冪等性 | 備考 |
+| ---- | -------- | ---- | -------- | ------ | ---- |
+| SELECT | reco / api | `relationship_code` + `occasion_code` + `is_active = true` | — | — | Pair 解決。該当行なしは Run 失敗または validation エラー |
+| SELECT | reco | Run 再現参照 | `pair_id` | — | `recommendation_run.pair_id` 経由 |
+| INSERT / UPDATE | database（seed / 運用） | 新規組み合わせ追加・無効化 | 全列 | seed は Upsert 想定 | MVP では管理 UI なし。migration/seed Task で投入 |
+| DELETE | — | MVP では原則禁止 | — | — | `is_active = false` で無効化。Master 削除は RESTRICT で防止 |
+
+---
+
+## 13. データ保持・削除
+
+| 観点 | 方針 |
+| ---- | ---- |
+| 保持期間 | 長期（設定正本） |
+| 削除方式 | 物理 DELETE 原則禁止 |
+| 削除条件 | — |
+| 論理削除 | `is_active = false` で無効化 |
+| アーカイブ | MVP 対象外 |
+
+---
+
+## 14. Migration / DDL
+
+| 項目 | 内容 |
+| ---- | ---- |
+| DDL対象 | `pair_master` |
+| migration単位 | 1 テーブル = 1 migration（DDL Task） |
+| 適用順序 | 物理ER §15: `relationship_master` / `occasion_master` の後、`recommendation_run` の `pair_id` FK 追加より前 |
+| rollback方針 | forward migration 主体。DROP は Human Review 必須 |
+| 破壊的変更有無 | `no`（初回 CREATE） |
+
+---
+
+## 15. セキュリティ・権限
+
+| 観点 | 方針 |
+| ---- | ---- |
+| 読み取り権限 | api / reco（service role 経由） |
+| 書き込み権限 | database 運用・seed のみ。Online / Batch 実行中の DML 更新なし |
+| service role利用 | Pair 解決・seed 投入に限定 |
+| 個人情報・機微情報 | 含まない |
+| ログ出力制限 | Pair マスタ内容を error ログに過剰出力しない |
+| Public API | Pair 情報（`pair_id` 含む）は Public API 応答に含めない（API-PUB-005 / API-PUB-006 備考） |
+
+---
+
+## 16. テスト観点
+
+| No | 観点 | 確認内容 | 種別 |
+| --: | ---- | -------- | ---- |
+| 1 | DDL適用 | CREATE TABLE / Index / FK / CHECK が定義どおり | migration |
+| 2 | PK / UNIQUE | 同一 `relationship_code` + `occasion_code` の重複が拒否される | migration |
+| 3 | Master FK | 存在しない `relationship_code` / `occasion_code` の INSERT が拒否される | migration |
+| 4 | Pair解決 | `is_active=true` の組み合わせのみ解決される | integration |
+| 5 | Run FK | `recommendation_run.pair_id` が `pair_master.pair_id` を参照できる | migration |
+| 6 | Public API | API-PUB-005 / API-PUB-006 が Pair 情報を返却しない | contract |
+| 7 | 権限 | web client から Direct DB アクセス不可 | manual |
+
+---
+
+## 17. 未決事項
+
+| No | 論点 | 判断が必要な理由 | 判断者 | 期限 | 備考 |
+| --: | ---- | ---------------- | ------ | ---- | ---- |
+| 1 | `is_active` 列の MVP 物理 DDL 採用 | Master 系と同様の無効化手段が必要か | Human | DDL Task 前 | Human Review #443 / #448 踏襲で整理 |
+| 2 | Master 物理 FK の ON DELETE 方針 | `RESTRICT` / `NO ACTION` の確定 | Human | DDL Task 前 | 本定義書は `RESTRICT` を推奨 |
+| 3 | 有効 Pair 組み合わせの seed 範囲 | 全組み合わせか代表組み合わせのみか | Human | seed Task 前 | Featureルール定義書 §17.3 参照 |
+| 4 | `pair_rule` の FK 参照方式 | `pair_id` 参照か `relationship_code` + `occasion_code` 参照か | Human | pair_rule テーブル定義 Task | Featureルール定義書 §17.3 は codes 参照 |
+
+### 17.1 Human Review 決定事項（先行 PR より踏襲）
+
+| No | 論点 | 決定内容 | 決定者 | 備考 |
+| --: | ---- | -------- | ------ | ---- |
+| 1 | `pair_id` の保持先 | **`recommendation_run`** に保持する | Human | 物理ER §17 No.1（PR #438 Human Review） |
+| 2 | Public API 非公開 | Pair 情報は API-PUB-005 / API-PUB-006 応答に含めない | Human | API契約仕様書備考 |
+| 3 | Master への FK 方針（Request 側） | `recommendation_request` は Master を **LOGICAL** 参照のまま | Human | #443 / #448。本テーブルは Master へ **物理 FK** を採用 |
+
+---
+
+## 18. 関連資料
+
+| 種別 | パス / URL | 用途 |
+| ---- | ---------- | ---- |
+| 物理ER | `docs/06_実装設計/database/物理ER.md` | §4.1 No.3・§9・§10・§11・§17 |
+| 論理ER | `docs/05_アプリケーション設計/アプリ/database/論理ER.md` | Master / Config 系（§11） |
+| テーブル一覧 | `docs/05_アプリケーション設計/アプリ/database/テーブル一覧.md` | §9 Master / Config系 |
+| enum定義書 | `docs/06_実装設計/database/enum定義書.md` | コード定義正本（本テーブルは enum 列なし） |
+| 参照テーブル定義 | `docs/06_実装設計/database/relationship_master_テーブル定義書.md` | Master 系方針（Human Review #443） |
+| 参照テーブル定義 | `docs/06_実装設計/database/occasion_master_テーブル定義書.md` | Master 系方針（Human Review #448） |
+| API契約 | `docs/06_実装設計/api/API-PUB-005_Relationshipマスタ取得API契約仕様書.md` | Pair 非公開方針 |
+| API契約 | `docs/06_実装設計/api/API-PUB-006_Occasionマスタ取得API契約仕様書.md` | Pair 非公開方針 |
+| Featureルール | `docs/04_ドメインモデル設計/Featureルール定義書.md` | §17.3 pair_rule |
+
+---
+
+## 19. レビュー観点
+
+- 論理ER §11.1 未掲載（物理ER §4.1 No.3 追加）の差分が明示されている
+- 物理ER §8〜§11・テーブル一覧 §9 と矛盾していない
+- `pair_id`（uuid PK）、`uq_pair_relationship_occasion`、Master 物理 FK、`recommendation_run.pair_id` 物理 FK が明確
+- Public API 非公開方針が明記されている
+- `relationship_master` / `occasion_master` テーブル定義書と Master 系方針が一貫している
+- DDL Task が CREATE TABLE を起こせる粒度である
+- secret や `.env` 実値が含まれていない

--- a/prompts/definitions/reviews/db-physical-design/table-spec-pair-master/pr-review.yaml
+++ b/prompts/definitions/reviews/db-physical-design/table-spec-pair-master/pr-review.yaml
@@ -1,0 +1,157 @@
+schema_version: "1.0"
+definition_type: "review"
+
+review:
+  id: "review-db-physical-design-table-spec-pair-master-pr"
+  title: "pair_master テーブル定義書 PRレビュー"
+  summary: "pair_master テーブル定義書 Task の PR を AI Review する。物理ER・論理ER・テーブル一覧との整合と table-spec テンプレ準拠を確認する。"
+  type: "task_pr_review"
+  status: "ready"
+
+work_mode: "ai-agent"
+
+branch:
+  no_branch: false
+  name: "docs/task-449-pair-master-table-spec"
+  base: "docs/epic-435-db-physical-design"
+  target: "docs/epic-435-db-physical-design"
+  worktree_required: true
+
+target:
+  pr: null
+  issue: 449
+  task_definition: "prompts/definitions/tasks/db-physical-design/table-spec-pair-master.yaml"
+  source_branch: "docs/task-449-pair-master-table-spec"
+  target_branch: "docs/epic-435-db-physical-design"
+  parent_epic_issue: "[Epic]db-physical-design:DB物理設計・構築"
+  parent_epic_branch: "docs/epic-435-db-physical-design"
+
+commands:
+  primary: "/review-pr"
+  allowed:
+    - "/review-pr"
+    - "/fix-review-comments"
+    - "/summarize-work"
+  next:
+    approve_for_human_review: "Human Review"
+    request_changes: "/fix-review-comments"
+    needs_human_decision: "Human Decision"
+    split_required: "/start-task"
+    blocked: null
+
+agent:
+  primary: "reviewer-ai"
+  support:
+    - "support-ai"
+  specialist:
+    docs: "docs-reviewer-ai"
+    test: null
+    contract: null
+    security: null
+  next:
+    fixer: "fixer-ai"
+    human: "human-reviewer"
+
+review_scope:
+  docs: true
+  source: false
+  tests: false
+  api_contract: false
+  db: true
+  generated: false
+  cicd: false
+  security: true
+  project_operation: true
+
+input:
+  task_definition:
+    path: "prompts/definitions/tasks/db-physical-design/table-spec-pair-master.yaml"
+    required: true
+  issue:
+    number: 449
+    required: true
+  pr:
+    number: null
+    required: true
+  diff:
+    required: true
+    compare_with: "docs/epic-435-db-physical-design"
+  docs:
+    - path: "docs/06_実装設計/database/pair_master_テーブル定義書.md"
+      required: true
+      purpose: "作成成果物の内容確認"
+    - path: "docs/06_実装設計/database/relationship_master_テーブル定義書.md"
+      required: true
+      purpose: "Master 系テーブル定義書との一貫性確認"
+    - path: "docs/06_実装設計/database/occasion_master_テーブル定義書.md"
+      required: true
+      purpose: "Master 系テーブル定義書との一貫性確認"
+    - path: "docs/06_実装設計/database/物理ER.md"
+      required: true
+      purpose: "テーブル分類・FK・Index 方針との整合"
+    - path: "docs/05_アプリケーション設計/アプリ/database/論理ER.md"
+      required: true
+      purpose: "エンティティ属性との整合"
+    - path: "docs/05_アプリケーション設計/アプリ/database/テーブル一覧.md"
+      required: true
+      purpose: "テーブル分類・用途との整合"
+    - path: "docs/06_実装設計/api/API-PUB-005_Relationshipマスタ取得API契約仕様書.md"
+      required: true
+      purpose: "Pair 非公開方針の確認"
+    - path: "docs/06_実装設計/api/API-PUB-006_Occasionマスタ取得API契約仕様書.md"
+      required: true
+      purpose: "Pair 非公開方針の確認"
+    - path: "prompts/templates/docs/table-spec.md"
+      required: true
+      purpose: "テンプレート章構成との整合"
+  test_results:
+    required: true
+    source: "pr_body"
+  ci_results:
+    required: false
+    source: "not_required"
+  templates:
+    review_outputs:
+      pr_comment: "prompts/templates/review/ai-review-comment.md"
+      slack: "prompts/templates/slack/ai-review-result.md"
+    deliverables: []
+
+review_points:
+  common:
+    - "Task Definition の scope を満たしているか"
+    - "out_of_scope（他テーブル / DDL / migration / apps / OpenAPI）が混在していないか"
+    - "acceptance_criteria を満たしているか"
+    - "Task PR target が親 Epic Branch であるか"
+  docs:
+    - "table-spec.md テンプレの主要章が充足しているか"
+    - "論理ER §11.1 未掲載（物理ER §4.1 No.3 追加）の差分が明示されているか"
+    - "Public API 非公開（API-PUB-005 / API-PUB-006 備考）が明記されているか"
+    - "relationship_master / occasion_master テーブル定義書と Master 系方針が一貫しているか"
+  db:
+    - "PK / Index / CHECK / UNIQUE が DDL Task へ展開できる粒度か"
+    - "`pair_id`（uuid PK）が明記されているか"
+    - "`relationship_code` / `occasion_code` への Master 物理 FK が明記されているか"
+    - "`uq_pair_relationship_occasion` が明記されているか"
+    - "`recommendation_run.pair_id` 被参照（物理 FK）が明記されているか"
+    - "Master 系の保持・削除方針が妥当か"
+  security:
+    - "secret / .env 実値が含まれていないか"
+
+acceptance_criteria:
+  review_outputs:
+    - "AI Review 結論（Human Reviewへ進行可 / 修正後に再AI Review / Human判断待ち）"
+    - "Blocker / Must / Should / Question の整理"
+    - "Human Review 観点の明示"
+
+human_decision_points:
+  - "`is_active` 列の MVP 物理 DDL 採用（Human Review #443 / #448 踏襲）"
+  - "Master 物理 FK の ON DELETE 方針（RESTRICT 推奨）"
+  - "有効 Pair 組み合わせの seed 定義範囲（seed Task へ引き継ぎ）"
+
+risk_points:
+  - "relationship_master / occasion_master の is_active=false 行を参照する Pair 行の扱い"
+  - "pair_rule テーブル定義 Task との FK 方針（codes 参照 vs pair_id 参照）の一貫性"
+
+notes:
+  - "対応 Task Definition: prompts/definitions/tasks/db-physical-design/table-spec-pair-master.yaml"
+  - "先行 Task: #440 / PR #441（enum 定義）、#442 / PR #443（relationship_master）、#445 / PR #448（occasion_master）"

--- a/prompts/definitions/tasks/db-physical-design/table-spec-pair-master.yaml
+++ b/prompts/definitions/tasks/db-physical-design/table-spec-pair-master.yaml
@@ -1,0 +1,187 @@
+schema_version: "1.0"
+definition_type: "task"
+
+task:
+  id: "task-db-physical-design-table-spec-pair-master"
+  title: "pair_master:Pair Masterテーブル定義書作成"
+  summary: "物理ER・論理ER・テーブル一覧・relationship_master / occasion_master テーブル定義書を入力に、pair_master のテーブル定義書を作成する。Phase2 子 Task ③（テーブル定義）の 3 件目 Task。"
+  phase: "06_実装設計"
+
+work_mode: "ai-agent"
+
+parent:
+  epic_id: "epic-db-physical-design"
+  epic_issue: "[Epic]db-physical-design:DB物理設計・構築"
+  epic_issue_number: 435
+  epic_branch: "docs/epic-435-db-physical-design"
+  related_issues:
+    - number: 440
+      purpose: "先行 Task ② enum/コード定義（merge 済み前提）"
+    - number: 442
+      purpose: "先行 Task ③ relationship_master テーブル定義書（merge 済み前提）"
+    - number: 445
+      purpose: "先行 Task ③ occasion_master テーブル定義書（merge 済み前提・構成踏襲）"
+  related_prs:
+    - number: 441
+      purpose: "Task ② PR（merge 済み前提）"
+    - number: 443
+      purpose: "Task ③ relationship_master PR（merge 済み前提・Human Review #443）"
+    - number: 448
+      purpose: "Task ③ occasion_master PR（merge 済み前提・Human Review #448）"
+
+commands:
+  primary: "/start-task"
+  allowed:
+    - "/start-task"
+    - "/work-issue"
+    - "/create-pr"
+    - "/fix-review-comments"
+    - "/summarize-work"
+  next:
+    success: "/work-issue"
+    review_fix: "/fix-review-comments"
+    blocked: null
+
+agent:
+  primary: "worker-ai"
+  support:
+    - "support-ai"
+  review:
+    - "reviewer-ai"
+    - "docs-reviewer-ai"
+
+background: |
+  Phase2 子 Task ③。実装フェーズ実行プロセス設計書 §6.3 の「テーブル定義書（1テーブル=1Task）」に対応。
+  物理ER §15 適用順序どおり Master / Config 系を継続する。
+  先行 Task ② enum 定義書・Task ③ relationship_master / occasion_master テーブル定義書（Human Review #443 / #448 反映）を前提とする。
+  物理ER §17 No.1 により `pair_id` は `recommendation_run` に保持する。
+
+objective: |
+  `pair_master` の物理カラム・制約・Index・更新仕様を table-spec.md テンプレ準拠で定義する。
+  後続 DDL Task が migration を作成できる粒度まで確定する。
+
+scope:
+  - "table-spec.md テンプレ準拠の pair_master テーブル定義書作成"
+  - "物理ER・論理ER・テーブル一覧との突合"
+  - "relationship_master / occasion_master テーブル定義書の章構成・MVP 方針を踏襲"
+  - "`pair_id`（uuid PK）、Master 物理 FK、`uq_pair_relationship_occasion`、`recommendation_run.pair_id` 物理 FK の明記"
+  - "Public API 非公開方針の明記"
+  - "Task / Review Definition の整備"
+
+out_of_scope:
+  - "他テーブルのテーブル定義書"
+  - "DDL・migration（Task ④⑤）"
+  - "db/seeds ファイルの作成（Task ⑤）"
+  - "apps/** 実装"
+  - "OpenAPI / generated 変更"
+
+input:
+  docs:
+    - path: "docs/06_実装設計/database/物理ER.md"
+      required: true
+      purpose: "テーブル分類・FK・Index 方針"
+    - path: "docs/06_実装設計/database/enum定義書.md"
+      required: true
+      purpose: "enum 参照（本テーブルは state enum なし）"
+    - path: "docs/05_アプリケーション設計/アプリ/database/論理ER.md"
+      required: true
+      purpose: "エンティティ属性・正本区分"
+    - path: "docs/05_アプリケーション設計/アプリ/database/テーブル一覧.md"
+      required: true
+      purpose: "テーブル分類・用途"
+    - path: "docs/06_実装設計/database/relationship_master_テーブル定義書.md"
+      required: true
+      purpose: "Master 系テーブル定義書の構成・MVP 方針（Human Review #443）の踏襲"
+    - path: "docs/06_実装設計/database/occasion_master_テーブル定義書.md"
+      required: true
+      purpose: "Master 系テーブル定義書の構成・MVP 方針（Human Review #448）の踏襲"
+    - path: "docs/06_実装設計/api/API-PUB-005_Relationshipマスタ取得API契約仕様書.md"
+      required: true
+      purpose: "Pair 非公開方針の確認"
+    - path: "docs/06_実装設計/api/API-PUB-006_Occasionマスタ取得API契約仕様書.md"
+      required: true
+      purpose: "Pair 非公開方針の確認"
+  templates:
+    - path: "prompts/templates/docs/table-spec.md"
+      required: true
+      purpose: "成果物テンプレート"
+
+output:
+  docs:
+    - path: "docs/06_実装設計/database/pair_master_テーブル定義書.md"
+      action: "create"
+      required: true
+      template: "prompts/templates/docs/table-spec.md"
+  files:
+    - path: "prompts/definitions/tasks/db-physical-design/table-spec-pair-master.yaml"
+      action: "create"
+      required: true
+    - path: "prompts/definitions/reviews/db-physical-design/table-spec-pair-master/pr-review.yaml"
+      action: "create"
+      required: true
+
+acceptance_criteria:
+  - "pair_master テーブル定義書が docs/06_実装設計/database/ に存在する"
+  - "物理ER・論理ER・テーブル一覧と矛盾しない"
+  - "relationship_master / occasion_master テーブル定義書と Master 系方針が一貫している"
+  - "`pair_id`（uuid PK）、Master 物理 FK、`uq_pair_relationship_occasion`、`recommendation_run.pair_id` 物理 FK が明記されている"
+  - "Public API 非公開が明記されている"
+  - "apps/** 変更がない"
+  - "Task PR target が親 Epic Branch"
+
+branch:
+  no_branch: false
+  summary: "pair-master-table-spec"
+  base: null
+  target: null
+  worktree_required: true
+
+project:
+  fields:
+    phase: "06_実装設計"
+    status: "Todo"
+    priority: "high"
+
+issue:
+  unit: "task"
+  type: "docs"
+  area: "db"
+
+dependencies:
+  issues:
+    - number: 440
+      purpose: "Task ② enum/コード定義 完了"
+    - number: 442
+      purpose: "Task ③ relationship_master テーブル定義 完了"
+    - number: 445
+      purpose: "Task ③ occasion_master テーブル定義 完了"
+  blocking: true
+
+parallel_control:
+  exclusive_files:
+    - "docs/06_実装設計/database/pair_master_テーブル定義書.md"
+  conflict_risk: "low"
+  db_impact: false
+
+test_policy:
+  manual_checks:
+    - "物理ER §8〜§11 とカラム・制約・FK の整合"
+    - "relationship_master / occasion_master への物理 FK 方針"
+    - "recommendation_run.pair_id 被参照（物理 FK）の明記"
+    - "Public API 非公開方針の明記"
+    - "apps 実装層への変更がないこと"
+  not_required:
+    - "unit test"
+  skip_reason:
+    "unit test": "Phase2 docs 整備 Task のため"
+
+review:
+  human_review_required: true
+  ai_review_required: true
+  specialist_reviews:
+    docs: true
+
+notes:
+  - "テーブル一覧 §1.1: Task 識別子は物理テーブル名 pair_master を使用"
+  - "pair_rule 等の後続 Rule Task は pair_master 完了後に着手可能"
+  - "Human Review #443 / #448 と同様、is_active 列の MVP 物理 DDL 採用要否を未決事項として整理する"


### PR DESCRIPTION
## Summary

- `pair_master` テーブル定義書を table-spec.md テンプレ準拠で作成
- Task Definition / Review Definition を追加
- `pair_id`（uuid PK）、`relationship_code` / `occasion_code` への Master 物理 FK、`uq_pair_relationship_occasion`、`recommendation_run.pair_id` 被参照（物理 FK）、Public API 非公開を明記

Closes #449

## 変更ファイル

- `docs/06_実装設計/database/pair_master_テーブル定義書.md`（新規）
- `prompts/definitions/tasks/db-physical-design/table-spec-pair-master.yaml`（新規）
- `prompts/definitions/reviews/db-physical-design/table-spec-pair-master/pr-review.yaml`（新規）

## scope 確認

- [x] Task Definition scope 内
- [x] out_of_scope（apps / DDL / migration / seed）変更なし
- [x] PR target: `docs/epic-435-db-physical-design`

## テスト・検証

### 実施済み（manual）

- [x] 物理ER §8〜§11・§17 とカラム・制約・FK の整合確認
- [x] relationship_master / occasion_master テーブル定義書との Master 系方針一貫性確認
- [x] API-PUB-005 / API-PUB-006 の Pair 非公開方針との整合確認
- [x] apps/** 変更なし

### 未実施

- unit test: Phase2 docs 整備 Task のため不要

## Human Review 観点

- `is_active` 列の MVP 物理 DDL 採用要否（#443 / #448 踏襲）
- Master 物理 FK の ON DELETE 方針（本定義書は RESTRICT 推奨）
- 有効 Pair 組み合わせの seed 定義範囲（seed Task へ引き継ぎ）
- `pair_rule` の FK 参照方式（codes vs pair_id）

## 依存

- #440 / PR #441（enum 定義 merge 済み）
- #442 / PR #443（relationship_master merge 済み）
- #445 / PR #448（occasion_master merge 済み）

## 未決事項

定義書 §17 参照:

1. `is_active` 列の MVP 物理 DDL 採用
2. Master 物理 FK の ON DELETE 方針確定
3. 有効 Pair 組み合わせの seed 範囲
4. `pair_rule` の FK 参照方式

Made with [Cursor](https://cursor.com)