### PR TITLE
docs: composite参照方針の追随（ドメイン定義・Human Decision・Task Definition）

### DIFF
--- a/ai-logs/human-decisions/2026-06-05-api-int-002-score-breakdown-debug-return-policy.md
+++ b/ai-logs/human-decisions/2026-06-05-api-int-002-score-breakdown-debug-return-policy.md
@@ -47,7 +47,9 @@ Internal API（API-INT-002）における `scoreBreakdown`（Item 単位）と `
 | -------- | -------------- |
 | `debug_payload`（Recommendation Result 定義書） | `data.metadata.debugPayload`（Run 単位・open object） |
 
-推奨キー（MVP・列挙のみ）: `evalCaseId`, `semanticConfigVersionId`, `modelVersionId`, `rankingConfigVersionId`, `phaseSummary`。追加キーは許容する。
+推奨キー（MVP・列挙のみ）: `evalCaseId`, `configName`, `versionLabel`, `modelVersionId`, `rankingConfigVersionId`, `phaseSummary`。追加キーは許容する。
+
+> **改定（2026-06-10 / Task #463）:** Semantic Config 参照は旧 `semanticConfigVersionId` から **`configName` + `versionLabel` composite** へ更新。API-INT-002 契約仕様書 §7.3.8 と整合。
 
 ### 2.4 欠落時の tolerant 処理
 

--- a/ai-logs/human-decisions/2026-06-10-semantic-config-version-public-reference-join-policy.md
+++ b/ai-logs/human-decisions/2026-06-10-semantic-config-version-public-reference-join-policy.md
@@ -120,6 +120,9 @@
 | API-PUB-002 / API設計方針書 §18.4 | レコメンド結果に version 参照を含めない方針を維持し、記述を composite に整合 |
 | `public-api.yaml` | `SemanticConfigMastersData` / `FeatureRuleMastersData` schema・examples を更新 |
 | `internal-reco-api.yaml` | `ExecutionInput` から `semanticConfigVersionId` を削除し composite フィールドを追加 |
+| RecommendationRequest / RecommendationResult 定義書 | JSON 例の `semantic_config_version_id` を内部 UUID 形式へ更新 |
+| `2026-06-05-api-int-002-score-breakdown-debug-return-policy.md` | `debugPayload` 推奨キーを `configName` + `versionLabel` に改定 |
+| Task Definition / pr-review yaml | composite 参照文言へ追随 |
 
 ---
 

--- a/docs/04_ドメインモデル設計/RecommendationRequest定義書.md
+++ b/docs/04_ドメインモデル設計/RecommendationRequest定義書.md
@@ -385,7 +385,7 @@ Recommendation Requestの入力条件は、以下の4分類で整理する。
 | `candidate_limit`            | number  | 任意 | 内部候補取得件数        |
 | `include_reason`             | boolean | 任意 | 推薦理由を生成するか    |
 | `include_debug_info`         | boolean | 任意 | デバッグ情報を含めるか  |
-| `semantic_config_version_id` | string  | 任意 | 使用するSemantic Config |
+| `semantic_config_version_id` | string  | 任意 | 使用する Semantic Config Version（**内部 UUID**。表面 ID `semantic_config_v001` 等は採用しない） |
 | `model_version_id`           | string  | 任意 | 使用するModel Version   |
 
 ---
@@ -409,6 +409,8 @@ Recommendation Requestの入力条件は、以下の4分類で整理する。
 | `include_reason`     |  true |       true | false可 |
 | `include_debug_info` | false |       true |    true |
 | 結果保存             |  true |       true |    true |
+
+> **API 境界（evaluation / batch）:** Internal API（API-INT-002）では `execution.configName` + `execution.versionLabel` の composite で version 指定を受け付ける。api は解決後、永続化・Run 固定には本項の `semantic_config_version_id`（UUID）を用いる（`semantic_config_version_テーブル定義書` §17.1）。
 
 ---
 
@@ -485,7 +487,7 @@ Recommendation Requestの入力条件は、以下の4分類で整理する。
     "candidate_limit": 100,
     "include_reason": true,
     "include_debug_info": true,
-    "semantic_config_version_id": "semantic_config_v001",
+    "semantic_config_version_id": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
     "model_version_id": "model_v001"
   }
 }

--- a/docs/04_ドメインモデル設計/RecommendationResult定義書.md
+++ b/docs/04_ドメインモデル設計/RecommendationResult定義書.md
@@ -224,7 +224,7 @@ MVPでは、1回のRequestに対して1回のRun、1つのResultを生成する�
 
 | 項目                         | 型     | 必須 | 内容                            |
 | ---------------------------- | ------ | ---: | ------------------------------- |
-| `semantic_config_version_id` | string | 推奨 | 使用したSemantic Config Version |
+| `semantic_config_version_id` | string | 推奨 | 使用した Semantic Config Version（**内部 UUID**） |
 | `model_version_id`           | string | 推奨 | 使用したModel Version           |
 | `ranking_config_version_id`  | string | 任意 | 使用したRanking Config Version  |
 | `reason_template_version_id` | string | 任意 | 使用したReason Template Version |
@@ -448,7 +448,7 @@ flowchart TD
   ],
   "metadata": {
     "mode": "ui",
-    "semantic_config_version_id": "semantic_config_v001",
+    "semantic_config_version_id": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
     "model_version_id": "model_v001"
   }
 }
@@ -470,7 +470,7 @@ flowchart TD
 | `debug_payload`             | evaluation / debug modeのみ返却     |
 | `version情報`               | evaluation / debug modeでは返却推奨 |
 
-> **debug mode / debug返却条件（API-INT-002）:** 本表の「debug時」「evaluation / debug mode」は、API-INT-002 契約仕様書 §7.3.8 の **debug返却条件**（`execution.mode = evaluation` OR `execution.includeDebugInfo = true`）に対応する。`score_breakdown` は `data.resultItems[].scoreBreakdown`、`debug_payload` は `data.metadata.debugPayload` にマッピングする（Issue #375）。
+> **debug mode / debug返却条件（API-INT-002）:** 本表の「debug時」「evaluation / debug mode」は、API-INT-002 契約仕様書 §7.3.8 の **debug返却条件**（`execution.mode = evaluation` OR `execution.includeDebugInfo = true`）に対応する。`score_breakdown` は `data.resultItems[].scoreBreakdown`、`debug_payload` は `data.metadata.debugPayload` にマッピングする（Issue #375）。`debugPayload` 推奨キーの Semantic Config 参照は `configName` + `versionLabel` composite（Task #463）。
 
 ---
 

--- a/prompts/definitions/reviews/api-pub-007-semantic-config-masters/pr-review.yaml
+++ b/prompts/definitions/reviews/api-pub-007-semantic-config-masters/pr-review.yaml
@@ -80,7 +80,7 @@ review_points:
   - "GRS-CFG-* / GRS-DB-* エラーコード整合"
   - "Semantic Concept / Feature Definition の Public 表面のみ"
   - "内部 Rule（semantic_rule / pair_rule）非含有"
-  - "API-PUB-008 との semanticConfigVersionId 整合"
+  - "API-PUB-008 との configName + versionLabel composite 整合"
   - "実装面混入なし"
   - "OpenAPI 実変更なし"
 

--- a/prompts/definitions/reviews/pub-007-semantic-config-masters-openapi/pr-review.yaml
+++ b/prompts/definitions/reviews/pub-007-semantic-config-masters-openapi/pr-review.yaml
@@ -23,7 +23,7 @@ review_points:
     - "契約仕様書 §6〜§8 との整合（Concept 0件200、Feature 0件500、未知Query 400）"
     - "semantic_rule / pair_rule / feature_normalization_version 非露出"
     - "featureGroup enum（social/symbolic）と MVP 8 次元 featureCode 整合"
-    - "API-PUB-008 との semanticConfigVersionId 整合前提が明記されていること"
+    - "API-PUB-008 との configName + versionLabel composite 整合前提が明記されていること"
     - "Orval / generated 未変更"
 
 issue:

--- a/prompts/definitions/reviews/pub-008-feature-rule-masters-openapi/pr-review.yaml
+++ b/prompts/definitions/reviews/pub-008-feature-rule-masters-openapi/pr-review.yaml
@@ -24,7 +24,7 @@ review_points:
     - "baseValueRules の ruleType discriminator（relationship/occasion）と条件付き必須"
     - "pair_rule / 正規化パラメータ非露出、isActive 非露出"
     - "featureBaseValue / featureDelta が 0.0〜1.0"
-    - "API-PUB-005/006/007 とのコード・semanticConfigVersionId 整合"
+    - "API-PUB-005/006/007 とのコード・configName + versionLabel composite 整合"
     - "Orval / generated 未変更"
 
 issue:

--- a/prompts/definitions/tasks/api-int-002-score-breakdown-debug-return-policy/spike.yaml
+++ b/prompts/definitions/tasks/api-int-002-score-breakdown-debug-return-policy/spike.yaml
@@ -55,7 +55,7 @@ objective: |
   - debug返却条件を満たすとき: resultItems[].scoreBreakdown 推奨、data.metadata.debugPayload 推奨（契約上必須ではない）
   - ui かつ includeDebugInfo=false、または batch かつ includeDebugInfo=false: 両方省略
   - 欠落時: SCORE_BREAKDOWN_MISSING 相当をログ（phase_log / error_log）に記録し HTTP 200 継続。warnings[] には載せない
-  - metadata.debugPayload: open object（追加キー許容）。推奨キーは evalCaseId / semanticConfigVersionId / modelVersionId / rankingConfigVersionId / phaseSummary
+  - metadata.debugPayload: open object（追加キー許容）。推奨キーは evalCaseId / configName / versionLabel / modelVersionId / rankingConfigVersionId / phaseSummary
   - Public API 非表面化: api が scoreBreakdown / metadata.debugPayload を Public へ渡さない（現行維持）
 
 scope:

--- a/prompts/definitions/tasks/api-pub-007-semantic-config-masters/api-contract-spec.yaml
+++ b/prompts/definitions/tasks/api-pub-007-semantic-config-masters/api-contract-spec.yaml
@@ -53,11 +53,11 @@ scope:
   - "API-PUB-007 の API 契約仕様書を新規作成する（成果物: API-PUB-007_Semantic設定取得API契約仕様書.md）"
   - "API基本情報（API ID / Public / GET / Endpoint / Provider / Consumer / 認証 / 冪等性 / MVP対象）を定義する"
   - "Request Header / Path / Query / Body（なし）を整理する"
-  - "Response Body（Semantic Config スナップショット: semanticConfigVersionId / semanticConcepts / featureDefinitions）を整理する"
+  - "Response Body（Semantic Config スナップショット: configName + versionLabel / semanticConcepts / featureDefinitions）を整理する"
   - "Error Response仕様（GRS-CFG-* / GRS-DB-* / GRS-REQ-*）を整理する"
   - "空配列・current Version 未設定の HTTP Status 方針を明示する"
   - "OpenAPI / Orval / generated 反映方針を整理する（方針のみ）"
-  - "API-PUB-008 との semanticConfigVersionId 整合方針を整理する"
+  - "API-PUB-008 との configName + versionLabel composite 整合方針を整理する"
   - "互換性・契約面テスト観点を整理する"
   - "未決事項・人間判断が必要な事項を明記する"
 


### PR DESCRIPTION
## Summary

Task #463 の `configName` + `versionLabel` composite 参照方針について、PR #480 以降に残っていた正本 docs / ai-logs / Task Definition を追随更新する。

- `RecommendationRequest定義書` / `RecommendationResult定義書`: JSON 例の `semantic_config_version_id` を内部 UUID 形式へ更新。API 境界注記を追加
- `2026-06-05-api-int-002-score-breakdown-debug-return-policy.md`: `debugPayload` 推奨キーを composite に改定
- `2026-06-10-...-join-policy.md`: §2.9 に追随対象を追記
- 関連 Task Definition / pr-review yaml の文言を composite に統一

## Test plan

- [x] `semantic_config_v001` が JSON 例から除去されていること
- [x] `semanticConfigVersionId` が推奨キー・Task Definition から除去されていること
- [x] ドメイン定義の `semantic_config_version_id` は内部 UUID として維持されていること

## 関連

- 親 PR: #480（Task #463 本体・Contract Task）
- Issue: #463（追随修正）


Made with [Cursor](https://cursor.com)